### PR TITLE
feat: add support for new M cores for M5 Pro/Max

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,9 +730,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-truncate"

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,18 +197,18 @@ impl<'a> App<'a> {
             }
         }
 
-        for (idx, m_cluster) in metrics.m_clusters.iter().enumerate() {
+        for (idx, p_cluster) in metrics.p_clusters.iter().enumerate() {
             // Cluster activity ratio.
-            let key = MetricKey::ClusterActivePercent(ClusterId::medium(idx as u8));
+            let key = MetricKey::ClusterActivePercent(ClusterId::performance(idx as u8));
             self.history
                 .entry(key)
                 .or_insert(signal::Signal::with_capacity(
                     self.history_size,
                     /* max */ 100.0,
                 ))
-                .push(100.0 * m_cluster.active_ratio());
+                .push(100.0 * p_cluster.active_ratio());
 
-            for cpu in &m_cluster.cpus {
+            for cpu in &p_cluster.cpus {
                 // Per-core activity ratio.
                 self.history
                     .entry(MetricKey::CpuActivePercent(cpu.id))
@@ -229,18 +229,18 @@ impl<'a> App<'a> {
             }
         }
 
-        for (idx, p_cluster) in metrics.p_clusters.iter().enumerate() {
+        for (idx, s_cluster) in metrics.s_clusters.iter().enumerate() {
             // Cluster activity ratio.
-            let key = MetricKey::ClusterActivePercent(ClusterId::performance(idx as u8));
+            let key = MetricKey::ClusterActivePercent(ClusterId::super_core(idx as u8));
             self.history
                 .entry(key)
                 .or_insert(signal::Signal::with_capacity(
                     self.history_size,
                     /* max */ 100.0,
                 ))
-                .push(100.0 * p_cluster.active_ratio());
+                .push(100.0 * s_cluster.active_ratio());
 
-            for cpu in &p_cluster.cpus {
+            for cpu in &s_cluster.cpus {
                 // Per-core activity ratio.
                 self.history
                     .entry(MetricKey::CpuActivePercent(cpu.id))

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,6 +197,38 @@ impl<'a> App<'a> {
             }
         }
 
+        for (idx, m_cluster) in metrics.m_clusters.iter().enumerate() {
+            // Cluster activity ratio.
+            let key = MetricKey::ClusterActivePercent(ClusterId::medium(idx as u8));
+            self.history
+                .entry(key)
+                .or_insert(signal::Signal::with_capacity(
+                    self.history_size,
+                    /* max */ 100.0,
+                ))
+                .push(100.0 * m_cluster.active_ratio());
+
+            for cpu in &m_cluster.cpus {
+                // Per-core activity ratio.
+                self.history
+                    .entry(MetricKey::CpuActivePercent(cpu.id))
+                    .or_insert(signal::Signal::with_capacity(
+                        self.history_size,
+                        /* max */ 100.0,
+                    ))
+                    .push(100.0 * cpu.active_ratio as f32);
+
+                // Per-core frequency.
+                self.history
+                    .entry(MetricKey::CpuFreqPercent(cpu.id))
+                    .or_insert(signal::Signal::with_capacity(
+                        self.history_size,
+                        /* max */ 100.0,
+                    ))
+                    .push(100.0 * cpu.freq_ratio() as f32);
+            }
+        }
+
         for (idx, p_cluster) in metrics.p_clusters.iter().enumerate() {
             // Cluster activity ratio.
             let key = MetricKey::ClusterActivePercent(ClusterId::performance(idx as u8));

--- a/src/metric_key.rs
+++ b/src/metric_key.rs
@@ -5,9 +5,11 @@
 
 /// Identifies a CPU cluster by its kind and index.
 ///
-/// Apple Silicon chips have efficiency (E) and performance (P) clusters.
+/// Apple Silicon chips have efficiency (E) and performance (P) clusters before M5.
 /// Single-die chips (M1, M2, M3) have one of each, while multi-die chips
 /// (M1 Ultra, M2 Ultra) have two of each.
+/// Starting with M5 there are super (P), medium (M), and efficiency (E) clusters.
+/// Single-die M5 has P+E clusters, while multi-die Pro/Max chips have P+M clusters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct ClusterId {
     pub kind: ClusterKind,
@@ -30,6 +32,14 @@ impl ClusterId {
             index,
         }
     }
+
+    /// Create a medium cluster ID.
+    pub const fn medium(index: u8) -> Self {
+        Self {
+            kind: ClusterKind::Medium,
+            index,
+        }
+    }
 }
 
 /// The kind of CPU cluster.
@@ -39,6 +49,8 @@ pub(crate) enum ClusterKind {
     Efficiency,
     /// Performance cores (P-cluster).
     Performance,
+    /// Medium cores (M-cluster).
+    Medium,
 }
 
 /// Type-safe key for accessing metrics in the history.

--- a/src/metric_key.rs
+++ b/src/metric_key.rs
@@ -5,11 +5,10 @@
 
 /// Identifies a CPU cluster by its kind and index.
 ///
-/// Apple Silicon chips have efficiency (E) and performance (P) clusters before M5.
+/// Apple Silicon chips have efficiency (E) and performance (P) clusters.
 /// Single-die chips (M1, M2, M3) have one of each, while multi-die chips
 /// (M1 Ultra, M2 Ultra) have two of each.
-/// Starting with M5 there are super (P), medium (M), and efficiency (E) clusters.
-/// Single-die M5 has P+E clusters, while multi-die Pro/Max chips have P+M clusters.
+/// Starting with M5 Pro/Max there are also super (S) clusters above performance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct ClusterId {
     pub kind: ClusterKind,
@@ -33,10 +32,10 @@ impl ClusterId {
         }
     }
 
-    /// Create a medium cluster ID.
-    pub const fn medium(index: u8) -> Self {
+    /// Create a super cluster ID.
+    pub const fn super_core(index: u8) -> Self {
         Self {
-            kind: ClusterKind::Medium,
+            kind: ClusterKind::Super,
             index,
         }
     }
@@ -49,8 +48,8 @@ pub(crate) enum ClusterKind {
     Efficiency,
     /// Performance cores (P-cluster).
     Performance,
-    /// Medium cores (M-cluster).
-    Medium,
+    /// Super cores (S-cluster).
+    Super,
 }
 
 /// Type-safe key for accessing metrics in the history.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,10 +26,10 @@ use crate::{
 pub(crate) struct Metrics {
     /// Efficiency Cluster metrics.
     pub(crate) e_clusters: Vec<ClusterMetrics>,
-    /// Medium Cluster metrics.
-    pub(crate) m_clusters: Vec<ClusterMetrics>,
     /// Performance Cluster metrics.
     pub(crate) p_clusters: Vec<ClusterMetrics>,
+    /// Super Cluster metrics (M5 Pro/Max and above).
+    pub(crate) s_clusters: Vec<ClusterMetrics>,
     /// GPU metrics.
     pub(crate) gpu: GpuMetrics,
     /// Power consumption in W of the CPU, GPU, ANE, and package.
@@ -61,8 +61,8 @@ impl Metrics {
     fn num_cpus(&self) -> usize {
         let mut total = 0;
         self.e_clusters.iter().for_each(|c| total += c.cpus.len());
-        self.m_clusters.iter().for_each(|c| total += c.cpus.len());
         self.p_clusters.iter().for_each(|c| total += c.cpus.len());
+        self.s_clusters.iter().for_each(|c| total += c.cpus.len());
         total
     }
 
@@ -110,20 +110,20 @@ impl Metrics {
                 cpu.active_ratio = *sysinfo_active_ratio as f64;
             }
         }
-        for m_cluster in &mut self.m_clusters {
-            for cpu in &mut m_cluster.cpus {
-                let sysinfo_active_ratio = sysinfo_metrics.get(&cpu.id).ok_or_else(|| {
-                    Error::MisalignedCpuId(format!("CPU id not found: {}", cpu.id))
-                })?;
-                cpu.active_ratio = *sysinfo_active_ratio as f64;
-            }
-        }
         for p_cluster in &mut self.p_clusters {
             for cpu in &mut p_cluster.cpus {
                 let update_active_ratio = sysinfo_metrics.get(&cpu.id).ok_or_else(|| {
                     Error::MisalignedCpuId(format!("CPU id not found: {}", cpu.id))
                 })?;
                 cpu.active_ratio = *update_active_ratio as f64;
+            }
+        }
+        for s_cluster in &mut self.s_clusters {
+            for cpu in &mut s_cluster.cpus {
+                let sysinfo_active_ratio = sysinfo_metrics.get(&cpu.id).ok_or_else(|| {
+                    Error::MisalignedCpuId(format!("CPU id not found: {}", cpu.id))
+                })?;
+                cpu.active_ratio = *sysinfo_active_ratio as f64;
             }
         }
 
@@ -151,21 +151,21 @@ impl From<plist_parsing::Metrics> for Metrics {
             .map(ClusterMetrics::from)
             .collect::<Vec<_>>();
 
-        // Collect all M clusters.
-        let m_clusters = value
-            .processor
-            .clusters
-            .iter()
-            .filter(|c| c.name.starts_with('M'))
-            .map(ClusterMetrics::from)
-            .collect::<Vec<_>>();
-
         // Collect all P clusters.
         let p_clusters = value
             .processor
             .clusters
             .iter()
             .filter(|c| c.name.starts_with('P'))
+            .map(ClusterMetrics::from)
+            .collect::<Vec<_>>();
+
+        // Collect all S clusters (Super cores, M5 Pro/Max and above).
+        let s_clusters = value
+            .processor
+            .clusters
+            .iter()
+            .filter(|c| c.name.starts_with('S'))
             .map(ClusterMetrics::from)
             .collect::<Vec<_>>();
 
@@ -187,8 +187,8 @@ impl From<plist_parsing::Metrics> for Metrics {
 
         Self {
             e_clusters,
-            m_clusters,
             p_clusters,
+            s_clusters,
             gpu,
             consumption,
             thermal_pressure: value.thermal_pressure,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,6 +26,8 @@ use crate::{
 pub(crate) struct Metrics {
     /// Efficiency Cluster metrics.
     pub(crate) e_clusters: Vec<ClusterMetrics>,
+    /// Medium Cluster metrics.
+    pub(crate) m_clusters: Vec<ClusterMetrics>,
     /// Performance Cluster metrics.
     pub(crate) p_clusters: Vec<ClusterMetrics>,
     /// GPU metrics.
@@ -59,6 +61,7 @@ impl Metrics {
     fn num_cpus(&self) -> usize {
         let mut total = 0;
         self.e_clusters.iter().for_each(|c| total += c.cpus.len());
+        self.m_clusters.iter().for_each(|c| total += c.cpus.len());
         self.p_clusters.iter().for_each(|c| total += c.cpus.len());
         total
     }
@@ -107,6 +110,14 @@ impl Metrics {
                 cpu.active_ratio = *sysinfo_active_ratio as f64;
             }
         }
+        for m_cluster in &mut self.m_clusters {
+            for cpu in &mut m_cluster.cpus {
+                let sysinfo_active_ratio = sysinfo_metrics.get(&cpu.id).ok_or_else(|| {
+                    Error::MisalignedCpuId(format!("CPU id not found: {}", cpu.id))
+                })?;
+                cpu.active_ratio = *sysinfo_active_ratio as f64;
+            }
+        }
         for p_cluster in &mut self.p_clusters {
             for cpu in &mut p_cluster.cpus {
                 let update_active_ratio = sysinfo_metrics.get(&cpu.id).ok_or_else(|| {
@@ -140,6 +151,15 @@ impl From<plist_parsing::Metrics> for Metrics {
             .map(ClusterMetrics::from)
             .collect::<Vec<_>>();
 
+        // Collect all M clusters.
+        let m_clusters = value
+            .processor
+            .clusters
+            .iter()
+            .filter(|c| c.name.starts_with('M'))
+            .map(ClusterMetrics::from)
+            .collect::<Vec<_>>();
+
         // Collect all P clusters.
         let p_clusters = value
             .processor
@@ -167,6 +187,7 @@ impl From<plist_parsing::Metrics> for Metrics {
 
         Self {
             e_clusters,
+            m_clusters,
             p_clusters,
             gpu,
             consumption,

--- a/src/ui/tab_cpu.rs
+++ b/src/ui/tab_cpu.rs
@@ -22,7 +22,7 @@ const ACTIVITY_HISTORY_LENGTH: u16 = 8;
 const FREQUENCY_LABEL_WIDTH: u16 = 6; // "freq: "
 const FREQUENCY_VALUE_WIDTH: u16 = 10; // "1070 MHz "
 const FREQUENCY_HISTORY_LENGTH: u16 = 8;
-const FREQUENCY_TABLE_HEIGHT: u16 = 4;
+const FREQUENCY_TABLE_HEIGHT: u16 = 5;
 
 /// Draw the per-core usage, and per-core frequency distribution.
 ///
@@ -66,6 +66,13 @@ pub(crate) fn draw_cpu_tab(f: &mut Frame, app: &App, area: Rect) {
         .e_clusters
         .iter()
         .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16))
+        // M-Clusters
+        .chain(
+            metrics
+                .m_clusters
+                .iter()
+                .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16)),
+        )
         // P-Clusters
         .chain(
             metrics
@@ -91,6 +98,12 @@ pub(crate) fn draw_cpu_tab(f: &mut Frame, app: &App, area: Rect) {
         let cluster_area = clu_area_iter
             .next()
             .expect("layout: expected area for E-cluster");
+        draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
+    }
+    for cluster in metrics.m_clusters.iter() {
+        let cluster_area = clu_area_iter
+            .next()
+            .expect("layout: expected area for M-cluster");
         draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
     }
     for cluster in metrics.p_clusters.iter() {
@@ -248,10 +261,31 @@ fn draw_cpu(f: &mut Frame, cpu: &CpuMetrics, history: &History, colors: &AppColo
 }
 
 fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
-    let e_cluster_frequencies = metrics.e_clusters[0].cpus[0].frequencies_mhz();
-    let p_cluster_frequencies = metrics.p_clusters[0].cpus[0].frequencies_mhz();
+    let e_cluster_frequencies = metrics
+        .e_clusters
+        .first()
+        .and_then(|c| c.cpus.first())
+        .map(|c| c.frequencies_mhz())
+        .unwrap_or_default();
+    let m_cluster_frequencies = metrics
+        .m_clusters
+        .first()
+        .and_then(|c| c.cpus.first())
+        .map(|c| c.frequencies_mhz())
+        .unwrap_or_default();
+    let p_cluster_frequencies = metrics
+        .p_clusters
+        .first()
+        .and_then(|c| c.cpus.first())
+        .map(|c| c.frequencies_mhz())
+        .unwrap_or_default();
 
     let e_clus = e_cluster_frequencies
+        .iter()
+        .map(|f| format!("{:4}", *f))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let m_clus = m_cluster_frequencies
         .iter()
         .map(|f| format!("{:4}", *f))
         .collect::<Vec<_>>()
@@ -261,15 +295,22 @@ fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
         .map(|f| format!("{:4}", *f))
         .collect::<Vec<_>>()
         .join(" ");
-    let row_content = [
-        ("E-Cluster:", e_clus),
-        ("P-Cluster:", p_clus),
-        ("", "".into()),
-        (
-            "Note:",
-            "Hardware-wise, CPUs quickly shift between the above frequencies.".into(),
-        ),
-    ];
+
+    let mut row_content: Vec<(&str, String)> = vec![];
+    if !e_clus.is_empty() {
+        row_content.push(("E-Cluster:", e_clus));
+    }
+    if !m_clus.is_empty() {
+        row_content.push(("M-Cluster:", m_clus));
+    }
+    if !p_clus.is_empty() {
+        row_content.push(("P-Cluster:", p_clus));
+    }
+    row_content.push(("", "".into()));
+    row_content.push((
+        "Note:",
+        "Hardware-wise, CPUs quickly shift between the above frequencies.".into(),
+    ));
 
     let rows = row_content.iter().map(|(left, ref right)| {
         Row::new(vec![

--- a/src/ui/tab_cpu.rs
+++ b/src/ui/tab_cpu.rs
@@ -66,17 +66,17 @@ pub(crate) fn draw_cpu_tab(f: &mut Frame, app: &App, area: Rect) {
         .e_clusters
         .iter()
         .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16))
-        // M-Clusters
-        .chain(
-            metrics
-                .m_clusters
-                .iter()
-                .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16)),
-        )
         // P-Clusters
         .chain(
             metrics
                 .p_clusters
+                .iter()
+                .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16)),
+        )
+        // S-Clusters
+        .chain(
+            metrics
+                .s_clusters
                 .iter()
                 .map(|cl| Constraint::Length(2 + CPU_BLOCK_HEIGHT * cl.cpus.len() as u16)),
         )
@@ -100,16 +100,16 @@ pub(crate) fn draw_cpu_tab(f: &mut Frame, app: &App, area: Rect) {
             .expect("layout: expected area for E-cluster");
         draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
     }
-    for cluster in metrics.m_clusters.iter() {
-        let cluster_area = clu_area_iter
-            .next()
-            .expect("layout: expected area for M-cluster");
-        draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
-    }
     for cluster in metrics.p_clusters.iter() {
         let cluster_area = clu_area_iter
             .next()
             .expect("layout: expected area for P-cluster");
+        draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
+    }
+    for cluster in metrics.s_clusters.iter() {
+        let cluster_area = clu_area_iter
+            .next()
+            .expect("layout: expected area for S-cluster");
         draw_cpu_cluster(f, cluster, &app.history, &app.colors, *cluster_area);
     }
 
@@ -267,8 +267,8 @@ fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
         .and_then(|c| c.cpus.first())
         .map(|c| c.frequencies_mhz())
         .unwrap_or_default();
-    let m_cluster_frequencies = metrics
-        .m_clusters
+    let s_cluster_frequencies = metrics
+        .s_clusters
         .first()
         .and_then(|c| c.cpus.first())
         .map(|c| c.frequencies_mhz())
@@ -285,7 +285,7 @@ fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
         .map(|f| format!("{:4}", *f))
         .collect::<Vec<_>>()
         .join(" ");
-    let m_clus = m_cluster_frequencies
+    let s_clus = s_cluster_frequencies
         .iter()
         .map(|f| format!("{:4}", *f))
         .collect::<Vec<_>>()
@@ -300,11 +300,11 @@ fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
     if !e_clus.is_empty() {
         row_content.push(("E-Cluster:", e_clus));
     }
-    if !m_clus.is_empty() {
-        row_content.push(("M-Cluster:", m_clus));
-    }
     if !p_clus.is_empty() {
         row_content.push(("P-Cluster:", p_clus));
+    }
+    if !s_clus.is_empty() {
+        row_content.push(("S-Cluster:", s_clus));
     }
     row_content.push(("", "".into()));
     row_content.push((

--- a/src/ui/tab_overview.rs
+++ b/src/ui/tab_overview.rs
@@ -71,8 +71,8 @@ pub(crate) fn draw_overview_tab(f: &mut Frame, app: &App, area: Rect) {
 
     // Number of horizontal blocks for the CPU clusters.
     let num_clusters_blocks = (num_blocks_for(metrics.e_clusters.len())
-        + num_blocks_for(metrics.m_clusters.len())
-        + num_blocks_for(metrics.p_clusters.len())) as u16;
+        + num_blocks_for(metrics.p_clusters.len())
+        + num_blocks_for(metrics.s_clusters.len())) as u16;
 
     let cls_block_height = GAUGE_HEIGHT + SPARKLINE_HEIGHT;
     let cpu_block_height =
@@ -140,8 +140,8 @@ fn draw_cpu_clusters_usage_block(
     area: Rect,
 ) {
     let num_cluster_blocks = num_blocks_for(metrics.e_clusters.len())
-        + num_blocks_for(metrics.m_clusters.len())
-        + num_blocks_for(metrics.p_clusters.len());
+        + num_blocks_for(metrics.p_clusters.len())
+        + num_blocks_for(metrics.s_clusters.len());
 
     let sig = history.get_or_default(&MetricKey::CpuPowerW);
     let title = "CPU Clusters";
@@ -207,39 +207,6 @@ fn draw_cpu_clusters_usage_block(
         }
     }
 
-    // Draw the metrics for the M cluster (or clusters).
-    // Yes this is duplicate code, but the alternative is to have a function with many arguments
-    // which is just used here.
-    for (chunk_idx, clu_slice) in metrics.m_clusters.chunks(2).enumerate() {
-        let area = clu_area_iter
-            .next()
-            .expect("layout: expected area for M-cluster block");
-
-        match clu_slice.len() {
-            1 => {
-                let cluster = &clu_slice[0];
-                let cluster_id = ClusterId::medium((chunk_idx * 2) as u8);
-                draw_cluster_overall_metrics(f, cluster, cluster_id, history, colors, *area);
-            }
-            2 => {
-                let (left_cluster, right_cluster) = (&clu_slice[0], &clu_slice[1]);
-                let left_id = ClusterId::medium((chunk_idx * 2) as u8);
-                let right_id = ClusterId::medium((chunk_idx * 2 + 1) as u8);
-                draw_cluster_pair_overall_metrics(
-                    f,
-                    left_cluster,
-                    left_id,
-                    right_cluster,
-                    right_id,
-                    history,
-                    colors,
-                    *area,
-                );
-            }
-            _ => unreachable!(),
-        }
-    }
-
     // Draw the metrics for the Performance cluster (or clusters).
     // Yes this is duplicate code, but the alternative is to have a function with many arguments
     // which is just used here.
@@ -258,6 +225,39 @@ fn draw_cpu_clusters_usage_block(
                 let (left_cluster, right_cluster) = (&clu_slice[0], &clu_slice[1]);
                 let left_id = ClusterId::performance((chunk_idx * 2) as u8);
                 let right_id = ClusterId::performance((chunk_idx * 2 + 1) as u8);
+                draw_cluster_pair_overall_metrics(
+                    f,
+                    left_cluster,
+                    left_id,
+                    right_cluster,
+                    right_id,
+                    history,
+                    colors,
+                    *area,
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Draw the metrics for the Super cluster (or clusters, M5 Pro/Max and above).
+    // Yes this is duplicate code, but the alternative is to have a function with many arguments
+    // which is just used here.
+    for (chunk_idx, clu_slice) in metrics.s_clusters.chunks(2).enumerate() {
+        let area = clu_area_iter
+            .next()
+            .expect("layout: expected area for S-cluster block");
+
+        match clu_slice.len() {
+            1 => {
+                let cluster = &clu_slice[0];
+                let cluster_id = ClusterId::super_core((chunk_idx * 2) as u8);
+                draw_cluster_overall_metrics(f, cluster, cluster_id, history, colors, *area);
+            }
+            2 => {
+                let (left_cluster, right_cluster) = (&clu_slice[0], &clu_slice[1]);
+                let left_id = ClusterId::super_core((chunk_idx * 2) as u8);
+                let right_id = ClusterId::super_core((chunk_idx * 2 + 1) as u8);
                 draw_cluster_pair_overall_metrics(
                     f,
                     left_cluster,

--- a/src/ui/tab_overview.rs
+++ b/src/ui/tab_overview.rs
@@ -71,6 +71,7 @@ pub(crate) fn draw_overview_tab(f: &mut Frame, app: &App, area: Rect) {
 
     // Number of horizontal blocks for the CPU clusters.
     let num_clusters_blocks = (num_blocks_for(metrics.e_clusters.len())
+        + num_blocks_for(metrics.m_clusters.len())
         + num_blocks_for(metrics.p_clusters.len())) as u16;
 
     let cls_block_height = GAUGE_HEIGHT + SPARKLINE_HEIGHT;
@@ -138,8 +139,9 @@ fn draw_cpu_clusters_usage_block(
     colors: &AppColors,
     area: Rect,
 ) {
-    let num_cluster_blocks =
-        num_blocks_for(metrics.e_clusters.len()) + num_blocks_for(metrics.p_clusters.len());
+    let num_cluster_blocks = num_blocks_for(metrics.e_clusters.len())
+        + num_blocks_for(metrics.m_clusters.len())
+        + num_blocks_for(metrics.p_clusters.len());
 
     let sig = history.get_or_default(&MetricKey::CpuPowerW);
     let title = "CPU Clusters";
@@ -190,6 +192,39 @@ fn draw_cpu_clusters_usage_block(
                 let (left_cluster, right_cluster) = (&clu_slice[0], &clu_slice[1]);
                 let left_id = ClusterId::efficiency((chunk_idx * 2) as u8);
                 let right_id = ClusterId::efficiency((chunk_idx * 2 + 1) as u8);
+                draw_cluster_pair_overall_metrics(
+                    f,
+                    left_cluster,
+                    left_id,
+                    right_cluster,
+                    right_id,
+                    history,
+                    colors,
+                    *area,
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Draw the metrics for the M cluster (or clusters).
+    // Yes this is duplicate code, but the alternative is to have a function with many arguments
+    // which is just used here.
+    for (chunk_idx, clu_slice) in metrics.m_clusters.chunks(2).enumerate() {
+        let area = clu_area_iter
+            .next()
+            .expect("layout: expected area for M-cluster block");
+
+        match clu_slice.len() {
+            1 => {
+                let cluster = &clu_slice[0];
+                let cluster_id = ClusterId::medium((chunk_idx * 2) as u8);
+                draw_cluster_overall_metrics(f, cluster, cluster_id, history, colors, *area);
+            }
+            2 => {
+                let (left_cluster, right_cluster) = (&clu_slice[0], &clu_slice[1]);
+                let left_id = ClusterId::medium((chunk_idx * 2) as u8);
+                let right_id = ClusterId::medium((chunk_idx * 2 + 1) as u8);
                 draw_cluster_pair_overall_metrics(
                     f,
                     left_cluster,


### PR DESCRIPTION
@graelo, please let me know if you're interested in that contribution. I'll can work on some improvements and tests.

Seems like with the new naming for M5, we have:
- Super == P
- new Performance == M aka Medium? (not sure if it actually means medium)
- new Efficient == E

M5 is E+P, but M5 Pro/Max are M+P, so it requires the addition of the new core type.
A18 Pro (MB Neo) likely has E+M based on specs.

TODO:
- [ ] fix showing cores in the header (still shows 12E+6P+40GPU for M5 Max)
- [ ] double check if M==Medium
- [ ] guess power numbers
- [ ] fix eff/perf cores in SoC tab