### PR TITLE
feat: Handle `Ctrl-C` and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to gather metrics.
 sudo pumas run
 ```
 
-Use the arrow keys to switch between tabs. Press `Esc`, `q` or `x` to quit.
+Use the arrow keys to switch between tabs. Press `Esc`, `q`, `x`, `Ctrl-C` to quit.
 
 ### Screenshots
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,6 +140,12 @@ impl<'a> App<'a> {
         }
     }
 
+    pub fn on_ctrl(&mut self, c: char) {
+        if c == 'c' {
+            self.should_quit = true;
+        }
+    }
+
     pub fn on_left(&mut self) {
         self.tabs.previous();
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,4 +55,12 @@ pub enum Error {
     /// Error killing powermetrics subprocess.
     #[error("failed to kill powermetrics: `{0}`")]
     PowermetricsKill(io::Error),
+
+    /// Error waiting for powermetrics subprocess to exit.
+    #[error("failed to wait for powermetrics: `{0}`")]
+    PowermetricsWait(io::Error),
+
+    /// Error powermetrics exited with non-zero status.
+    #[error("exited with non-zero status: `{0}`, stderr: \"{1}\"")]
+    PowermetricsNonZeroExit(i32, String),
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -92,6 +92,7 @@ where
                 Key::Left | Key::BackTab => app.on_left(),
                 Key::Right | Key::Char('\t') => app.on_right(),
                 Key::Char(c) => app.on_key(c),
+                Key::Ctrl(c) => app.on_ctrl(c),
                 _ => {}
             },
             Event::Metrics(metrics) => app.on_metrics(metrics),

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -2,7 +2,7 @@
 
 use std::{
     error::Error,
-    io::{self, BufRead, BufReader},
+    io::{self, BufRead, BufReader, Write},
     process,
     sync::mpsc,
     thread,
@@ -51,12 +51,18 @@ pub fn run(args: RunConfig) -> Result<()> {
 
             let app = App::new(soc_info, args.colors(), args.history_size);
 
-            main_ui_loop(
+            let result = main_ui_loop(
                 &mut terminal,
                 app,
                 Duration::from_millis(args.sample_rate_ms as u64),
-            )
-            .expect("Cannot continue to run the app");
+            );
+
+            drop(terminal);
+            io::stdout().flush().ok(); // Avoid error message being cleaned by terminal cleanup.
+
+            if let Err(err) = result {
+                eprintln!("Error:\n    {}", err);
+            }
         }
     }
 
@@ -67,6 +73,8 @@ enum Event {
     Input(Key),
     // Tick,
     Metrics(metrics::Metrics),
+    // When metrics return an error
+    Error(Box<CrateError>),
 }
 
 /// Start the event stream sources and launch the UI event loop.
@@ -96,6 +104,9 @@ where
                 _ => {}
             },
             Event::Metrics(metrics) => app.on_metrics(metrics),
+            Event::Error(err) => {
+                return Err(err);
+            }
         }
         if app.should_quit {
             return Ok(());
@@ -150,8 +161,10 @@ fn start_event_threads(tick_rate: Duration) -> mpsc::Receiver<Event> {
     // });
 
     thread::spawn(move || {
-        if let Err(err) = stream_metrics(tick_rate, tx) {
-            eprintln!("powermetrics error: {err}");
+        if let Err(err) = stream_metrics(tick_rate, tx.clone()) {
+            if let Err(send_err) = tx.send(Event::Error(Box::new(err))) {
+                eprintln!("Error sending error event: {}", send_err);
+            }
         }
     });
 
@@ -190,6 +203,7 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
     let mut cmd = process::Command::new(binary)
         .args(&args)
         .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
         .spawn()
         .map_err(CrateError::PowermetricsSpawn)?;
 
@@ -245,7 +259,21 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
         }
     }
 
-    cmd.try_wait().map_err(CrateError::PowermetricsKill)?;
+    let status = cmd.wait().map_err(CrateError::PowermetricsWait)?;
+    if !status.success() && status.code().is_some()
+    // if powermetrics is killed, status.code() is None
+    {
+        let mut err_msg = String::new();
+        if let Some(mut stderr) = cmd.stderr.take() {
+            use std::io::Read;
+            stderr.read_to_string(&mut err_msg).ok();
+        }
+
+        return Err(CrateError::PowermetricsNonZeroExit(
+            status.code().unwrap(),
+            err_msg.trim().to_string(),
+        ));
+    }
     Ok(())
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -61,6 +61,20 @@ pub fn run(args: RunConfig) -> Result<()> {
             io::stdout().flush().ok(); // Avoid error message being cleaned by terminal cleanup.
 
             if let Err(err) = result {
+                if let Some(crate_err) = err.downcast_ref::<CrateError>() {
+                    // Try to print more helpful error messages
+                    match crate_err {
+                        CrateError::PowermetricsNonZeroExit(code, stderr) => {
+                            eprintln!("powermetrics exited abnormally with code {code}. Stderr:\n    {stderr}");
+                            if *code == 1 {
+                                eprintln!("This is likely caused by a permission issue. Sudo is required to run Pumas, as it uses Apple's powermetrics to gather metrics. Please try running with sudo:\n\n    sudo pumas run\n");
+                            }
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
+                }
+
                 eprintln!("Error:\n    {}", err);
             }
         }


### PR DESCRIPTION
Fixes #53 

## Changes
### Add `Ctrl-C` handler
- The main UI loop (`src/monitor.rs:73`) now listens for `Ctrl-C` and handling just like other keys (e.g. `q`, `x`).
- Updated `README.md` to include `Ctrl-C` as a quit option.

### Fix and enhance the error handling for `powermetrics`
- Fix the stuck on TUI if `powermetrics` quit abnormally. If `powermetrics` subprocess exit abnormally, the error now will promote to the top run function (`src/monitor.rs:37`). The error will be print correctly and make TUI quit gracefully.
- Added specific handling for cases where `powermetrics` exits with code 1 (a common permission error). The application now displays a user friendly message telling user to run the command with `sudo`.

**Running without `sudo`(Before):**
<img width="600" height="777" alt="Screenshot 2026-04-03 at 21 39 51" src="https://github.com/user-attachments/assets/efa9707c-9272-4d56-9c80-b90e7362c85d" />

**Running without `sudo`(After):**
<img width="600" height="777" alt="Screenshot 2026-04-03 at 21 41 18" src="https://github.com/user-attachments/assets/0f3a746f-b07c-4ff2-926a-f7a0e39b8cd0" />

