### PR TITLE
chore(ci): split cargo-outdated and strengthen version checks

### DIFF
--- a/.github/workflows/check-outdated.yml
+++ b/.github/workflows/check-outdated.yml
@@ -1,0 +1,32 @@
+# Runs cargo-outdated when the `check-outdated` label is added to a PR
+
+name: Outdated
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  check-outdated:
+    name: Check outdated deps
+    runs-on: macos-latest
+    if: github.event.label.name == 'check-outdated'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Quality - cargo outdated
+        timeout-minutes: 20
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(gh api repos/kbknapp/cargo-outdated/releases/latest --jq '.tag_name')
+          curl -sSfL "https://github.com/kbknapp/cargo-outdated/releases/download/${VERSION}/cargo-outdated-${VERSION#v}-aarch64-apple-darwin.tar.gz" | \
+            gtar zx
+          chmod +x cargo-outdated
+          mv cargo-outdated ~/.cargo/bin/
+          rm -rf ~/.cargo/advisory-db
+          cargo outdated --exit-code 1

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -67,30 +67,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(curl -sH "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | jq -r '.tag_name')
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "::error::Failed to fetch cargo-deny version from GitHub API"
-            exit 1
-          fi
-          echo "Installing cargo-deny $VERSION"
+          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
           curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-aarch64-apple-darwin.tar.gz" | \
             gtar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
-
-      - name: Quality - cargo outdated
-        if: github.event_name == 'pull_request'
-        timeout-minutes: 20
-        run: |
-          cargo install --locked cargo-outdated || true
-          #     VERSION=$(curl -s https://api.github.com/repos/kbknapp/cargo-outdated/releases/latest | jq -r '.tag_name')
-          #     curl -sSfL "https://github.com/kbknapp/cargo-outdated/releases/download/${VERSION}/cargo-outdated-${VERSION#v}-aarch64-apple-darwin.tar.gz" | \
-          #       gtar zx
-          #     chmod +x cargo-outdated
-          #     mv cargo-outdated ~/.cargo/bin/
-          #     rm -rf ~/.cargo/advisory-db
-          cargo outdated --exit-code 1
 
       - name: Quality - cargo pants
         run: |


### PR DESCRIPTION
## Summary

- Replace `curl` + `jq` with `gh api --jq` for fetching the latest cargo-deny
  release tag — simpler, and `gh` handles auth via `GITHUB_TOKEN` automatically
- Move `cargo-outdated` out of `essentials.yml` into a dedicated
  `check-outdated.yml` workflow, triggered by adding the `check-outdated` label
  to a PR (or via `workflow_dispatch`)

## Motivation

Aligns CI patterns with tmux-backup. The `gh api` approach is less fragile (no
manual null-checks needed), and separating the outdated check avoids its long
compile/run time blocking every PR.
