### PR TITLE
feat: handle Ctrl-C and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to gather metrics.
 sudo pumas run
 ```
 
-Use the arrow keys to switch between tabs. Press `Esc`, `q` or `x` to quit.
+Use the arrow keys to switch between tabs. Press `Esc`, `q`, `x`, `Ctrl-C` to quit.
 
 ### Screenshots
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to gather metrics.
 sudo pumas run
 ```
 
-Use the arrow keys to switch between tabs. Press `Esc`, `q`, `x`, `Ctrl-C` to quit.
+Use the arrow keys to switch between tabs. Press `Esc`, `q` or `x` to quit.
 
 ### Screenshots
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,6 +140,12 @@ impl<'a> App<'a> {
         }
     }
 
+    pub fn on_ctrl(&mut self, c: char) {
+        if c == 'c' {
+            self.should_quit = true;
+        }
+    }
+
     pub fn on_left(&mut self) {
         self.tabs.previous();
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,4 +55,12 @@ pub enum Error {
     /// Error killing powermetrics subprocess.
     #[error("failed to kill powermetrics: `{0}`")]
     PowermetricsKill(io::Error),
+
+    /// Error waiting for powermetrics subprocess to exit.
+    #[error("failed to wait for powermetrics: `{0}`")]
+    PowermetricsWait(io::Error),
+
+    /// Error powermetrics exited with non-zero status.
+    #[error("exited with non-zero status: `{0}`, stderr: \"{1}\"")]
+    PowermetricsNonZeroExit(i32, String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! This crate's error type.
 
-use std::io;
+use std::{io, process};
 
 /// Describes all errors from this crate.
 ///
@@ -56,11 +56,7 @@ pub enum Error {
     #[error("failed to kill powermetrics: `{0}`")]
     PowermetricsKill(io::Error),
 
-    /// Error waiting for powermetrics subprocess to exit.
-    #[error("failed to wait for powermetrics: `{0}`")]
-    PowermetricsWait(io::Error),
-
     /// Error powermetrics exited with non-zero status.
-    #[error("exited with non-zero status: `{0}`, stderr: \"{1}\"")]
-    PowermetricsNonZeroExit(i32, String),
+    #[error("powermetrics ({0}), error: `{1}`")]
+    PowermetricsNonZeroExit(process::ExitStatus, String),
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -92,6 +92,7 @@ where
                 Key::Left | Key::BackTab => app.on_left(),
                 Key::Right | Key::Char('\t') => app.on_right(),
                 Key::Char(c) => app.on_key(c),
+                Key::Ctrl(c) => app.on_ctrl(c),
                 _ => {}
             },
             Event::Metrics(metrics) => app.on_metrics(metrics),

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,7 +1,6 @@
 //! The monitor main loop.
 
 use std::{
-    error::Error,
     io::{self, BufRead, BufReader, Write},
     process,
     sync::mpsc,
@@ -37,11 +36,8 @@ use crate::{
 pub fn run(args: RunConfig) -> Result<()> {
     let soc_info = SocInfo::new()?;
 
-    match args.json {
-        true => {
-            main_exporter_loop(soc_info, Duration::from_millis(args.sample_rate_ms as u64))
-                .expect("Cannot continue exporting metrics");
-        }
+    let result = match args.json {
+        true => main_exporter_loop(soc_info, Duration::from_millis(args.sample_rate_ms as u64)),
         false => {
             let stdout = io::stdout().into_raw_mode()?.into_alternate_screen()?;
             let stdout = MouseTerminal::from(stdout);
@@ -58,24 +54,17 @@ pub fn run(args: RunConfig) -> Result<()> {
             );
 
             drop(terminal);
-            io::stdout().flush().ok(); // Avoid error message being cleaned by terminal cleanup.
+            io::stdout().flush().ok();
 
-            if let Err(err) = result {
-                if let Some(crate_err) = err.downcast_ref::<CrateError>() {
-                    // Try to print more helpful error messages
-                    match crate_err {
-                        CrateError::PowermetricsNonZeroExit(code, stderr) => {
-                            eprintln!("powermetrics exited abnormally with code {code}. Stderr:\n    {stderr}");
-                            if *code == 1 {
-                                eprintln!("This is likely caused by a permission issue. Sudo is required to run Pumas, as it uses Apple's powermetrics to gather metrics. Please try running with sudo:\n\n    sudo pumas run\n");
-                            }
-                            return Ok(());
-                        }
-                        _ => {}
-                    }
-                }
+            result
+        }
+    };
 
-                eprintln!("Error:\n    {}", err);
+    if let Err(err) = result {
+        eprintln!("{err}");
+        if let CrateError::PowermetricsNonZeroExit(status, msg) = &err {
+            if status.code() == Some(1) && msg.contains("superuser") {
+                eprintln!("macOS requires superuser privileges to access power metrics.\n\n    sudo pumas run\n");
             }
         }
     }
@@ -87,8 +76,7 @@ enum Event {
     Input(Key),
     // Tick,
     Metrics(metrics::Metrics),
-    // When metrics return an error
-    Error(Box<CrateError>),
+    Error(CrateError),
 }
 
 /// Start the event stream sources and launch the UI event loop.
@@ -96,18 +84,17 @@ fn main_ui_loop<B: Backend>(
     terminal: &mut Terminal<B>,
     mut app: App,
     tick_rate: Duration,
-) -> std::result::Result<(), Box<dyn Error>>
+) -> Result<()>
 where
-    <B as Backend>::Error: 'static,
+    CrateError: From<B::Error>,
 {
     let events = start_event_threads(tick_rate);
 
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
-        match events.recv()? {
-            // Event::Tick => app.on_tick(),
-            Event::Input(key) => match key {
+        match events.recv() {
+            Ok(Event::Input(key)) => match key {
                 Key::Esc => app.on_key('q'),
                 // Key::Up => app.on_up(),
                 // Key::Down => app.on_down(),
@@ -117,29 +104,32 @@ where
                 Key::Ctrl(c) => app.on_ctrl(c),
                 _ => {}
             },
-            Event::Metrics(metrics) => app.on_metrics(metrics),
-            Event::Error(err) => {
-                return Err(err);
-            }
+            Ok(Event::Metrics(metrics)) => app.on_metrics(metrics),
+            Ok(Event::Error(err)) => return Err(err),
+            Err(_) => break,
         }
         if app.should_quit {
             return Ok(());
         }
     }
+
+    Ok(())
 }
 
 /// Start the event stream sources and export metrics as JSON.
-fn main_exporter_loop(
-    soc_info: SocInfo,
-    tick_rate: Duration,
-) -> std::result::Result<(), Box<dyn Error>> {
+fn main_exporter_loop(soc_info: SocInfo, tick_rate: Duration) -> Result<()> {
     let events = start_event_threads(tick_rate);
 
     loop {
-        if let Event::Metrics(metrics) = events.recv()? {
-            export(&soc_info, metrics)
+        match events.recv() {
+            Ok(Event::Metrics(metrics)) => export(&soc_info, metrics),
+            Ok(Event::Error(err)) => return Err(err),
+            Ok(_) => {}
+            Err(_) => break,
         }
     }
+
+    Ok(())
 }
 
 fn export(soc_info: &SocInfo, metrics: metrics::Metrics) {
@@ -176,8 +166,8 @@ fn start_event_threads(tick_rate: Duration) -> mpsc::Receiver<Event> {
 
     thread::spawn(move || {
         if let Err(err) = stream_metrics(tick_rate, tx.clone()) {
-            if let Err(send_err) = tx.send(Event::Error(Box::new(err))) {
-                eprintln!("Error sending error event: {}", send_err);
+            if let Err(send_err) = tx.send(Event::Error(err)) {
+                eprintln!("failed to send error event: {send_err}");
             }
         }
     });
@@ -273,21 +263,19 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
         }
     }
 
-    let status = cmd.wait().map_err(CrateError::PowermetricsWait)?;
-    if !status.success() && status.code().is_some()
-    // if powermetrics is killed, status.code() is None
-    {
+    let status = cmd.wait()?;
+    if !status.success() && status.code().is_some() {
         let mut err_msg = String::new();
         if let Some(mut stderr) = cmd.stderr.take() {
             use std::io::Read;
             stderr.read_to_string(&mut err_msg).ok();
         }
-
         return Err(CrateError::PowermetricsNonZeroExit(
-            status.code().unwrap(),
+            status,
             err_msg.trim().to_string(),
         ));
     }
+
     Ok(())
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -2,7 +2,7 @@
 
 use std::{
     error::Error,
-    io::{self, BufRead, BufReader},
+    io::{self, BufRead, BufReader, Write},
     process,
     sync::mpsc,
     thread,
@@ -51,12 +51,18 @@ pub fn run(args: RunConfig) -> Result<()> {
 
             let app = App::new(soc_info, args.colors(), args.history_size);
 
-            main_ui_loop(
+            let result = main_ui_loop(
                 &mut terminal,
                 app,
                 Duration::from_millis(args.sample_rate_ms as u64),
-            )
-            .expect("Cannot continue to run the app");
+            );
+
+            drop(terminal);
+            io::stdout().flush().ok(); // Avoid error message being cleaned by terminal cleanup.
+
+            if let Err(err) = result {
+                eprintln!("Error:\n    {}", err);
+            }
         }
     }
 
@@ -67,6 +73,8 @@ enum Event {
     Input(Key),
     // Tick,
     Metrics(metrics::Metrics),
+    // When metrics return an error
+    Error(Box<CrateError>),
 }
 
 /// Start the event stream sources and launch the UI event loop.
@@ -96,6 +104,9 @@ where
                 _ => {}
             },
             Event::Metrics(metrics) => app.on_metrics(metrics),
+            Event::Error(err) => {
+                return Err(err);
+            }
         }
         if app.should_quit {
             return Ok(());
@@ -150,8 +161,10 @@ fn start_event_threads(tick_rate: Duration) -> mpsc::Receiver<Event> {
     // });
 
     thread::spawn(move || {
-        if let Err(err) = stream_metrics(tick_rate, tx) {
-            eprintln!("powermetrics error: {err}");
+        if let Err(err) = stream_metrics(tick_rate, tx.clone()) {
+            if let Err(send_err) = tx.send(Event::Error(Box::new(err))) {
+                eprintln!("Error sending error event: {}", send_err);
+            }
         }
     });
 
@@ -190,6 +203,7 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
     let mut cmd = process::Command::new(binary)
         .args(&args)
         .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
         .spawn()
         .map_err(CrateError::PowermetricsSpawn)?;
 
@@ -245,7 +259,21 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
         }
     }
 
-    cmd.try_wait().map_err(CrateError::PowermetricsKill)?;
+    let status = cmd.wait().map_err(CrateError::PowermetricsWait)?;
+    if !status.success() && status.code().is_some()
+    // if powermetrics is killed, status.code() is None
+    {
+        let mut err_msg = String::new();
+        if let Some(mut stderr) = cmd.stderr.take() {
+            use std::io::Read;
+            stderr.read_to_string(&mut err_msg).ok();
+        }
+
+        return Err(CrateError::PowermetricsNonZeroExit(
+            status.code().unwrap(),
+            err_msg.trim().to_string(),
+        ));
+    }
     Ok(())
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -61,6 +61,20 @@ pub fn run(args: RunConfig) -> Result<()> {
             io::stdout().flush().ok(); // Avoid error message being cleaned by terminal cleanup.
 
             if let Err(err) = result {
+                if let Some(crate_err) = err.downcast_ref::<CrateError>() {
+                    // Try to print more helpful error messages
+                    match crate_err {
+                        CrateError::PowermetricsNonZeroExit(code, stderr) => {
+                            eprintln!("powermetrics exited abnormally with code {code}. Stderr:\n    {stderr}");
+                            if *code == 1 {
+                                eprintln!("This is likely caused by a permission issue. Sudo is required to run Pumas, as it uses Apple's powermetrics to gather metrics. Please try running with sudo:\n\n    sudo pumas run\n");
+                            }
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
+                }
+
                 eprintln!("Error:\n    {}", err);
             }
         }


### PR DESCRIPTION
Closes #53

## Summary

- Add `Ctrl-C` handling to quit the application
- Fix TUI exit to show a proper error message when `powermetrics` crashes (e.g. running without root)
- Provide helpful hint for common `powermetrics` exit codes
- Update README to mention `Ctrl-C` as a quit option
- Simplify error handling for `powermetrics` failures

## Credits

Based on the work by @kunlinglio in #54 — thank you for the contribution! This PR rebases those changes onto the latest `main` with a minor refactor on top.