### PR TITLE
build: bump to Rust edition 2024 with MSRV 1.88

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           filters: |
             cargo_lock:
+              - 'Cargo.toml'
               - 'Cargo.lock'
             workflows:
               - '.github/workflows/**'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pumas"
 version = "0.4.0"
-edition = "2021"
-rust-version = "1.80.0"
+edition = "2024"
+rust-version = "1.88.0"
 description = "A power usage monitor for Apple Silicon."
 readme = "README.md"
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=pumas
-MSRV=1.80
+MSRV=1.88
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -28,7 +28,7 @@ if ! check_version $MSRV ; then
 fi
 
 FEATURES=()
-# check_version 1.80 && FEATURES+=(libm)
+# check_version 1.88 && FEATURES+=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 set -x

--- a/examples/memory_ratio_test.rs
+++ b/examples/memory_ratio_test.rs
@@ -14,22 +14,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pages_compressed = 0u64;
 
     for line in output_str.lines() {
-        if let Some(ps) = line.strip_prefix("Mach Virtual Memory Statistics: (page size of ") {
-            if let Some(size_str) = ps.strip_suffix(" bytes)") {
-                page_size = size_str.parse().unwrap_or(4096);
-            }
-        } else if line.contains("Anonymous pages:") {
-            if let Some(val) = line.split(':').nth(1) {
-                pages_anonymous = val.trim().trim_end_matches('.').parse().unwrap_or(0);
-            }
-        } else if line.contains("Pages wired down:") {
-            if let Some(val) = line.split(':').nth(1) {
-                pages_wired = val.trim().trim_end_matches('.').parse().unwrap_or(0);
-            }
-        } else if line.contains("Pages occupied by compressor:") {
-            if let Some(val) = line.split(':').nth(1) {
-                pages_compressed = val.trim().trim_end_matches('.').parse().unwrap_or(0);
-            }
+        if let Some(ps) = line.strip_prefix("Mach Virtual Memory Statistics: (page size of ")
+            && let Some(size_str) = ps.strip_suffix(" bytes)")
+        {
+            page_size = size_str.parse().unwrap_or(4096);
+        } else if line.contains("Anonymous pages:")
+            && let Some(val) = line.split(':').nth(1)
+        {
+            pages_anonymous = val.trim().trim_end_matches('.').parse().unwrap_or(0);
+        } else if line.contains("Pages wired down:")
+            && let Some(val) = line.split(':').nth(1)
+        {
+            pages_wired = val.trim().trim_end_matches('.').parse().unwrap_or(0);
+        } else if line.contains("Pages occupied by compressor:")
+            && let Some(val) = line.split(':').nth(1)
+        {
+            pages_compressed = val.trim().trim_end_matches('.').parse().unwrap_or(0);
         }
     }
 

--- a/src/bin/pumas.rs
+++ b/src/bin/pumas.rs
@@ -4,8 +4,9 @@ use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 
 use pumas::{
+    Result,
     config::{Command, Config},
-    monitor, Result,
+    monitor,
 };
 
 fn main() -> Result<()> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,9 +8,9 @@ use std::str::FromStr;
 use serde::Serialize;
 
 use crate::{
+    Result,
     error::Error,
     modules::{powermetrics::plist_parsing, sysinfo},
-    Result,
 };
 
 /// Reformulated metrics from the output of the `powermetrics` tool and `sysinfo`.

--- a/src/modules/soc.rs
+++ b/src/modules/soc.rs
@@ -2,7 +2,7 @@
 
 use std::process;
 
-use crate::{error::Error, Result};
+use crate::{Result, error::Error};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use ratatui::{
-    backend::{Backend, TermionBackend},
     Terminal,
+    backend::{Backend, TermionBackend},
 };
 use termion::{
     event::Key,
@@ -20,12 +20,13 @@ use termion::{
 };
 
 use crate::{
+    Result,
     app::App,
     config::RunConfig,
     error::Error as CrateError,
     metrics,
     modules::{powermetrics, soc::SocInfo, sysinfo},
-    ui, Result,
+    ui,
 };
 
 /// Launch the main loop.
@@ -62,10 +63,13 @@ pub fn run(args: RunConfig) -> Result<()> {
 
     if let Err(err) = result {
         eprintln!("{err}");
-        if let CrateError::PowermetricsNonZeroExit(status, msg) = &err {
-            if status.code() == Some(1) && msg.contains("superuser") {
-                eprintln!("macOS requires superuser privileges to access power metrics.\n\n    sudo pumas run\n");
-            }
+        if let CrateError::PowermetricsNonZeroExit(status, msg) = &err
+            && status.code() == Some(1)
+            && msg.contains("superuser")
+        {
+            eprintln!(
+                "macOS requires superuser privileges to access power metrics.\n\n    sudo pumas run\n"
+            );
         }
     }
 
@@ -165,10 +169,10 @@ fn start_event_threads(tick_rate: Duration) -> mpsc::Receiver<Event> {
     // });
 
     thread::spawn(move || {
-        if let Err(err) = stream_metrics(tick_rate, tx.clone()) {
-            if let Err(send_err) = tx.send(Event::Error(err)) {
-                eprintln!("failed to send error event: {send_err}");
-            }
+        if let Err(err) = stream_metrics(tick_rate, tx.clone())
+            && let Err(send_err) = tx.send(Event::Error(err))
+        {
+            eprintln!("failed to send error event: {send_err}");
         }
     });
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,6 @@
 //! A signal is a collection of points that can be used to draw a line graph.
 
-use num_traits::{cast::ToPrimitive, Bounded, Num};
+use num_traits::{Bounded, Num, cast::ToPrimitive};
 
 pub(crate) struct Signal<T>
 where

--- a/src/ui/main_screen.rs
+++ b/src/ui/main_screen.rs
@@ -1,11 +1,11 @@
 //! Definition of the UI.
 
 use ratatui::{
+    Frame,
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Tabs},
-    Frame,
 };
 
 use crate::app::App;

--- a/src/ui/startup_screen.rs
+++ b/src/ui/startup_screen.rs
@@ -1,11 +1,11 @@
 //! Startup screen.
 
 use ratatui::{
+    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text,
     widgets::{Paragraph, Wrap},
-    Frame,
 };
 
 const LOGO2_HEIGHT: u16 = 17;

--- a/src/ui/tab_cpu.rs
+++ b/src/ui/tab_cpu.rs
@@ -1,12 +1,12 @@
 //! CPU cores tab.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     symbols,
     text::Span,
     widgets::{Block, Borders, Cell, LineGauge, Paragraph, Row, Sparkline, Table},
-    Frame,
 };
 
 use crate::{
@@ -312,7 +312,7 @@ fn draw_freq_table(f: &mut Frame, metrics: &Metrics, area: Rect) {
         "Hardware-wise, CPUs quickly shift between the above frequencies.".into(),
     ));
 
-    let rows = row_content.iter().map(|(left, ref right)| {
+    let rows = row_content.iter().map(|(left, right)| {
         Row::new(vec![
             Cell::from(Span::from(*left)),
             Cell::from(Span::styled(

--- a/src/ui/tab_gpu.rs
+++ b/src/ui/tab_gpu.rs
@@ -1,12 +1,12 @@
 //! GPU tab.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
     text::{Line, Span},
     widgets::{Block, Borders, Cell, LineGauge, Paragraph, Row, Sparkline, Table},
-    Frame,
 };
 
 use crate::{
@@ -236,7 +236,7 @@ fn draw_freq_table(f: &mut Frame, gpu_metrics: &GpuMetrics, area: Rect) {
         ),
     ];
 
-    let rows = row_content.iter().map(|(left, ref right)| {
+    let rows = row_content.iter().map(|(left, right)| {
         Row::new(vec![
             Cell::from(Span::from(*left)),
             Cell::from(Span::styled(

--- a/src/ui/tab_memory.rs
+++ b/src/ui/tab_memory.rs
@@ -1,11 +1,11 @@
 //! Memory tab.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-    Frame,
 };
 
 use crate::{app::App, modules::vm_stat::VmStats, units};

--- a/src/ui/tab_overview.rs
+++ b/src/ui/tab_overview.rs
@@ -1,12 +1,12 @@
 //! Overview tab.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     symbols,
     text::{Line, Span, Text},
     widgets::{Block, Borders, Gauge, Paragraph, Sparkline},
-    Frame,
 };
 
 use crate::{

--- a/src/ui/tab_soc.rs
+++ b/src/ui/tab_soc.rs
@@ -1,11 +1,11 @@
 //! SoC tab.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Rect},
     style::{Modifier, Style},
     text::Span,
     widgets::{Cell, Row, Table},
-    Frame,
 };
 
 use crate::{app::App, units};
@@ -31,7 +31,7 @@ pub(crate) fn draw_soc_tab(f: &mut Frame, app: &App, area: Rect) {
         ("Max ANE power:", units::watts(app.soc_info.max_ane_w)),
     ];
 
-    let rows = row_content.iter().map(|(left, ref right)| {
+    let rows = row_content.iter().map(|(left, right)| {
         Row::new(vec![
             Cell::from(Span::from(*left)),
             Cell::from(Span::styled(


### PR DESCRIPTION
Upgrade from edition 2021 to 2024, raising the minimum supported Rust version to 1.88.

Edition 2024 disallows explicit `ref` bindings in implicitly-borrowing patterns and flags collapsible `if` blocks that can use let-chains. Both are fixed across the affected source files and the memory_ratio_test example. Import ordering changes from `cargo fmt` under the new edition are separated into their own commit.