### PR TITLE
Harden CI: fix version comments, reduce retention, enable vuln alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
-          retention-days: 3
+          retention-days: 1
 
   release:
     name: Create a GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
@@ -90,7 +90,7 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,12 @@
   "cargo": {
     "enabled": true
   },
-  "vulnerabilityAlerts": {
-    "enabled": false
-  },
   "packageRules": [
     {
       "description": "Pin GitHub Actions to commit SHAs for supply chain safety",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "pinDigests": true
     },
     {


### PR DESCRIPTION
Loose version comments (`# v7`, `# v8`) on SHA-pinned actions break Renovate's
digest lookup when the repo lacks a floating major-version tag. Replace them
with the exact tags (v7.0.1, v8.0.1).

Artifact retention drops from 3 days to 1 — artifacts only need to survive
until the release job downloads them, and shorter retention saves Actions
storage quota.

The explicit `vulnerabilityAlerts: { enabled: false }` block in renovate.json
is removed so `config:recommended` defaults kick in and Renovate starts raising
vulnerability PRs.