### PR TITLE
Bump MSRV to 1.95 and use let-else in UI tabs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pumas"
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "A power usage monitor for Apple Silicon."
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![crate](https://img.shields.io/crates/v/pumas.svg)](https://crates.io/crates/pumas)
 [![documentation](https://docs.rs/pumas/badge.svg)](https://docs.rs/pumas)
-[![minimum rustc 1.80](https://img.shields.io/badge/rustc-1.80+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
-[![rust 2021 edition](https://img.shields.io/badge/edition-2021-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
+[![minimum rustc 1.95](https://img.shields.io/badge/rustc-1.95+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![rust 2024 edition](https://img.shields.io/badge/edition-2024-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 <!-- [![build status](https://github.com/graelo/pumas/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/pumas/actions/workflows/essentials.yml) -->
 
 ![logo](./images/pumas-logo.svg)

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=pumas
-MSRV=1.88
+MSRV=1.95
 
 get_rust_version() {
   local array=($(rustc --version));

--- a/src/ui/tab_cpu.rs
+++ b/src/ui/tab_cpu.rs
@@ -56,10 +56,7 @@ const FREQUENCY_TABLE_HEIGHT: u16 = 5;
 /// └──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ///
 pub(crate) fn draw_cpu_tab(f: &mut Frame, app: &App, area: Rect) {
-    let metrics = match &app.metrics {
-        Some(metrics) => metrics,
-        None => return,
-    };
+    let Some(metrics) = &app.metrics else { return };
 
     let constraints = metrics
         // E-Clusters

--- a/src/ui/tab_gpu.rs
+++ b/src/ui/tab_gpu.rs
@@ -25,10 +25,7 @@ const POWER_HISTORY_LENGTH: u16 = 8;
 
 /// Draw the GPU tab.
 pub(crate) fn draw_gpu_tab(f: &mut Frame, app: &App, area: Rect) {
-    let metrics = match &app.metrics {
-        Some(metrics) => metrics,
-        None => return,
-    };
+    let Some(metrics) = &app.metrics else { return };
 
     let gpu_chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/tab_overview.rs
+++ b/src/ui/tab_overview.rs
@@ -64,10 +64,7 @@ const PKG_TEXT_HEIGHT: u16 = 1;
 /// └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ///
 pub(crate) fn draw_overview_tab(f: &mut Frame, app: &App, area: Rect) {
-    let metrics = match &app.metrics {
-        Some(metrics) => metrics,
-        None => return,
-    };
+    let Some(metrics) = &app.metrics else { return };
 
     // Number of horizontal blocks for the CPU clusters.
     let num_clusters_blocks = (num_blocks_for(metrics.e_clusters.len())


### PR DESCRIPTION
Bump MSRV from 1.88 to 1.95 across Cargo.toml, the CI test script, and
README badges (which still referenced rustc 1.80 and edition 2021).

Also replaced the three match-on-Option early-return patterns in tab
drawing functions with `let ... else`, which is more idiomatic. The rest
of the codebase already uses modern patterns like `if let` chains with
`&&` guards, so nothing else needed updating.