### PR TITLE
Fix poutine-action version to support config file

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Run poutine
-        uses: boostsecurityio/poutine-action@a563bfa02c3e093e52fb82f53eab0d3a0f348c34 # main (2026-04-07)
+        uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
 
       - name: Upload SARIF
         if: always()


### PR DESCRIPTION
Pin poutine-action to v1.1.4 instead of a main branch commit. The
previous pin predated .github/poutine.yml config file support, so skip
rules were silently ignored and code scanning flagged false positives
on taiki-e/install-action — blocking Renovate PRs from merging.