### PR TITLE
feat(run): auto-elevate with sudo when not root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -452,6 +452,7 @@ dependencies = [
  "num-traits",
  "plist",
  "ratatui",
+ "rpassword",
  "serde",
  "serde_json",
  "si-scale",
@@ -538,6 +539,27 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -882,11 +904,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -897,6 +944,54 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ clap_complete = "4.2.0"
 
 thiserror = "2"
 
+rpassword = "7"
+
 plist = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 si-scale = "0.3"

--- a/src/bin/pumas.rs
+++ b/src/bin/pumas.rs
@@ -1,5 +1,9 @@
 //! Main runner
 
+use std::io::Write;
+use std::os::unix::process::CommandExt;
+use std::process::exit;
+
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 
@@ -9,10 +13,98 @@ use pumas::{
     monitor,
 };
 
+/// Re-exec via `sudo` if not already running as root.
+fn ensure_root() {
+    if is_root() {
+        return;
+    }
+
+    // Credentials still cached from a recent run — elevate straight away.
+    if sudo_credentials_cached() {
+        reexec_sudo();
+    }
+
+    // Prompt for password and validate until successful.
+    loop {
+        let password = rpassword::prompt_password(
+            "Pumas requires root privileges to read power metrics.\nPassword: ",
+        )
+        .unwrap_or_else(|_| {
+            eprintln!("error: failed to read password");
+            exit(1);
+        });
+
+        let mut child = std::process::Command::new("sudo")
+            .arg("-S")
+            .arg("-v")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap_or_else(|_| {
+                eprintln!("error: failed to execute sudo");
+                exit(1);
+            });
+
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = writeln!(stdin, "{password}");
+        }
+
+        let status = child.wait().unwrap_or_else(|_| {
+            eprintln!("error: failed to wait for sudo");
+            exit(1);
+        });
+
+        if status.success() {
+            break;
+        }
+
+        eprintln!("Sorry, incorrect password. Try again.");
+    }
+
+    reexec_sudo();
+}
+
+/// Check whether sudo credentials are already cached (no password needed).
+fn sudo_credentials_cached() -> bool {
+    std::process::Command::new("sudo")
+        .arg("-n")
+        .arg("-v")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Replace the current process with `sudo pumas …`.
+///
+/// Uses `exec()` so sudo takes over this process directly — no parent/child
+/// split that could interfere with the TUI's terminal handling.
+fn reexec_sudo() -> ! {
+    let args: Vec<String> = std::env::args().collect();
+    let err = std::process::Command::new("sudo")
+        .args(&args)
+        .exec();
+
+    eprintln!("error: failed to execute sudo: {err}");
+    exit(1);
+}
+
+fn is_root() -> bool {
+    std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .is_some_and(|uid| uid == 0)
+}
+
 fn main() -> Result<()> {
     let config = Config::parse();
     match config.command {
         Command::Run { args } => {
+            ensure_root();
             monitor::run(args)?;
         }
 


### PR DESCRIPTION
## Summary

- Automatically re-executes with `sudo` when not running as root, instead of requiring the user to manually run `sudo pumas run`
- Prompts for the sudo password via a clean, framed prompt (no raw `Password:` prompt from sudo)
- Detects cached sudo credentials via `sudo -n -v` so re-runs within sudo's timeout window skip the prompt entirely
- Uses `exec()` (via `CommandExt`) for the elevation so there's no lingering parent process to interfere with the TUI's terminal handling

## Implementation

1. **`is_root()`** — checks EUID via `id -u`
2. **`sudo_credentials_cached()`** — runs `sudo -n -v` (non-interactive validate): returns early if cached
3. **Password prompt** — uses `rpassword` crate for secure no-echo input
4. **Validation** — pipes the password to `sudo -S -v` (validate + cache)
5. **Elevation** — `CommandExt::exec()` replaces the current process with `sudo pumas …`

A new dependency `rpassword` (v7) is added for safe password entry.

## Test plan

- [ ] Run `cargo build` (note: MSRV 1.95)
- [ ] Run from non-root: `pumas run` → prompts for password → elevates → TUI works
- [ ] Re-run within sudo timeout → no prompt → TUI works
- [ ] Enter wrong password → retry prompt shown
- [ ] Run `pumas generate-completion` (no sudo needed) → works without prompting
- [ ] Previously working `sudo pumas run` continues to work unchanged

🤖 Generated with Claude Code
