### PR TITLE
feat(web): add web dashboard with axum + ECharts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,10 +65,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -81,6 +153,21 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -167,6 +254,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +344,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +417,92 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "ident_case"
@@ -330,6 +590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,10 +605,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "ntapi"
@@ -403,10 +702,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plist"
@@ -447,17 +764,21 @@ name = "pumas"
 version = "0.5.0"
 dependencies = [
  "assert_approx_eq",
+ "axum",
  "clap",
  "clap_complete",
  "num-traits",
  "plist",
  "ratatui",
+ "rust-embed",
  "serde",
  "serde_json",
  "si-scale",
  "sysinfo",
  "termion",
  "thiserror",
+ "tokio",
+ "tower-http",
 ]
 
 [[package]]
@@ -541,6 +862,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +906,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -596,10 +960,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "si-scale"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa6635fb52805fa49a5798346e553cda9fd7990da8fbb2b3b2b9cf26589b4571"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "static_assertions"
@@ -644,6 +1064,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "sysinfo"
@@ -723,6 +1149,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +1308,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +1344,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,12 @@ num-traits = "0.2"
 serde_json = "1.0.104"
 sysinfo = "0.38"
 
+# web dashboard
+axum = "0.7"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs"] }
+tower-http = { version = "0.5", features = ["fs", "cors"] }
+rust-embed = "8"
+
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 

--- a/docs/webdashboard.md
+++ b/docs/webdashboard.md
@@ -1,0 +1,159 @@
+# Web Dashboard
+
+Web-based dashboard for Pumas using **axum** (Rust HTTP framework) and **ECharts** (JavaScript charting library).
+
+## Plan
+
+### Motivation
+
+Pumas already provides a TUI (`pumas run`) and JSON export (`pumas run --json`). A web dashboard makes the same data accessible from any browser, with richer visualizations (ECharts) and an easily customizable layout.
+
+### Design Goals
+
+- Serve a browser-based dashboard from the same `pumas` binary (no separate frontend build step)
+- Frontend assets embedded in the binary via `rust-embed` — zero external files at runtime
+- User-editable `config.js` for chart layout, colors, refresh rate
+- Light/dark theme with automatic system preference detection
+- `--web-dir` flag to override embedded assets with a local directory for customization without rebuilding
+
+### Implementation Order
+
+1. Add dependencies: `axum`, `tokio`, `tower-http`, `rust-embed` to `Cargo.toml`
+2. Add `WebConfig` struct and `Command::Web` variant to `src/config.rs`
+3. Create frontend: `web/index.html`, `web/app.js`, `web/config.js`, `web/style.css`
+4. Create backend: `src/web.rs` — axum HTTP server with routes
+5. Add `run_web()` and metrics streaming to `src/monitor.rs`
+6. Wire up: register module in `src/lib.rs`, add dispatch in `src/bin/pumas.rs`
+
+## Architecture
+
+```
+powermetrics ──std thread──► Arc<RwLock<Option<Metrics>>>
+                                       │
+                             axum HTTP server
+                            ┌─────┼─────────┐
+                            ▼     ▼         ▼
+                       GET /  GET /api/   GET /assets/*
+                     index.html  metrics    (static files)
+```
+
+### Data Flow
+
+1. **Metrics Collection** runs in a standard thread (powermetrics requires synchronous I/O). It spawns `/usr/bin/powermetrics`, parses the plist output, merges with sysinfo CPU data, and writes the result to `Arc<RwLock<Option<Metrics>>>`.
+2. **axum Server** runs on a separate tokio runtime. HTTP handlers read from the same shared state on each request.
+3. **Frontend** polls `/api/metrics` every `refreshInterval` ms and updates ECharts charts in-place.
+
+### Key Components
+
+| Layer | File | Role |
+| --- | --- | --- |
+| Frontend | `web/index.html` | Dashboard HTML with ECharts CDN, chart containers, memory/thermal DOM |
+| Frontend | `web/app.js` | Polling loop, ECharts instances, history buffers (60 samples), theme toggle |
+| Frontend | `web/config.js` | User-editable layout configuration |
+| Frontend | `web/style.css` | CSS custom properties for light/dark themes |
+| Backend | `src/web.rs` | axum HTTP server with 4 routes |
+| Backend | `src/monitor.rs` | `run_web()` entry point, `stream_powermetrics_to_state()` |
+| Config | `src/config.rs` | `WebConfig` struct + `Command::Web` variant |
+
+### Dependencies Added
+
+- `axum = "0.7"` — async HTTP framework
+- `tokio = { features = ["rt-multi-thread", "macros", "sync", "fs"] }` — async runtime + file I/O
+- `tower-http = { features = ["fs"] }` — (added but ServeDir not used; kept for future use)
+- `rust-embed = "8"` — embed `web/` directory in the binary
+
+## Implementation
+
+### Usage
+
+```sh
+sudo pumas web
+```
+
+Opens at `http://127.0.0.1:9810`.
+
+#### CLI Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-i, --sample-rate` | `1000` | Polling interval (ms, min 100) |
+| `-a, --listen-address` | `127.0.0.1:9810` | HTTP listen address |
+| `--web-dir` | — | Override embedded web assets with files from this directory |
+
+### Backend: `src/web.rs`
+
+```rust
+#[derive(RustEmbed)]
+#[folder = "web/"]
+struct Assets;
+```
+
+Routes:
+- `GET /` → serves `index.html` (from embedded assets or `--web-dir`)
+- `GET /assets/*path` → serves static files (JS, CSS)
+- `GET /api/metrics` → `{ soc: SocInfo, metrics: Option<Metrics> }` as JSON
+- `GET /api/config` → `{ soc: SocInfo }` as JSON
+
+File resolution: if `--web-dir` is set, the server checks that directory first for any requested file, falling back to the embedded assets. This allows users to customize `config.js`, `app.js`, or `style.css` without rebuilding.
+
+### Backend: Metrics Collection (`src/monitor.rs`)
+
+`run_web()` creates the shared state, spawns a std thread running `stream_powermetrics_to_state()`, then starts the axum server on a tokio runtime:
+
+```rust
+pub fn run_web(args: WebConfig) -> Result<()> {
+    let state = Arc::new(SharedMetricsState { ... });
+    thread::spawn(move || stream_powermetrics_to_state(tick_rate, &state));
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(crate::web::serve(state, args.listen_address))?;
+}
+```
+
+`stream_powermetrics_to_state()` is a dedicated version of the existing `stream_metrics()` that writes directly to `Arc<RwLock<Option<Metrics>>>` instead of sending through an mpsc channel.
+
+### Frontend: Config-Driven Layout
+
+The `config.js` file controls chart positions, sizes, visibility, and titles. The `app.js` init loop reads it and applies grid positioning dynamically:
+
+```js
+for (const [key, chart] of Object.entries(cfg)) {
+    card.style.gridRow = (chart.row + 1).toString();
+    card.style.gridColumn = `${chart.col + 1} / span ${chart.width}`;
+}
+```
+
+The layout uses a 12-column CSS grid. Chips with multiple SoC cluster types (E/P/S cores) render one line series per cluster.
+
+### Frontend: Charts
+
+| Chart | Type | Data |
+| --- | --- | --- |
+| CPU Utilization | Multi-line, 0-100% | One series per cluster, 60-sample rolling history |
+| CPU Frequency | Multi-line, MHz | One series per cluster, 60-sample rolling history |
+| GPU | Dual Y-axis | Utilization % + Frequency MHz, 60-sample history |
+| Power | Stacked area + dashed line | CPU/GPU/ANE stack + Package total, 60-sample history |
+| Memory | Progress bars | RAM used/total, Swap used/total (formatted bytes) |
+| Thermal | Colored label + fill bar | nominal / light / moderate / heavy / critical |
+
+### Frontend: Theme
+
+- CSS custom properties for light/dark themes, toggled via button or system preference
+- ECharts theme switches via `echarts.init(dom, null)` / `echarts.init(dom, 'dark')`
+- Preference persisted to `localStorage`
+
+## Files Changed
+
+| File | Status |
+| --- | --- |
+| `Cargo.toml` | Modified — added axum, tokio, tower-http, rust-embed |
+| `src/config.rs` | Modified — added `WebConfig`, `Command::Web` |
+| `src/web.rs` | **New** — axum server module |
+| `src/monitor.rs` | Modified — added `run_web()`, `stream_powermetrics_to_state()` |
+| `src/lib.rs` | Modified — registered `mod web` |
+| `src/error.rs` | Modified — added `WebServerError` |
+| `src/modules/soc.rs` | Modified — added `Clone` derive |
+| `src/bin/pumas.rs` | Modified — added `Command::Web` dispatch |
+| `web/index.html` | **New** — dashboard HTML |
+| `web/app.js` | **New** — dashboard application logic |
+| `web/config.js` | **New** — user-editable configuration |
+| `web/style.css` | **New** — dashboard styles |

--- a/src/bin/pumas.rs
+++ b/src/bin/pumas.rs
@@ -16,6 +16,10 @@ fn main() -> Result<()> {
             monitor::run(args)?;
         }
 
+        Command::Web { args } => {
+            monitor::run_web(args)?;
+        }
+
         Command::GenerateCompletion { shell } => {
             let mut app = Config::command();
             let name = app.get_name().to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,13 @@ pub enum Command {
         args: RunConfig,
     },
 
+    /// Start a web dashboard server.
+    Web {
+        /// Configuration for the web server.
+        #[command(flatten)]
+        args: WebConfig,
+    },
+
     /// Print a shell completion script to stdout.
     GenerateCompletion {
         /// Shell for which you want completion.
@@ -83,6 +90,23 @@ impl RunConfig {
             history_bg: self.history_bg_color,
         }
     }
+}
+
+/// Web dashboard configuration.
+#[derive(Debug, clap::Args)]
+pub struct WebConfig {
+    /// Update rate [ms], min=100.
+    #[arg(short = 'i', long = "sample-rate", default_value = "1000",
+        value_parser = clap::value_parser!(u16).range(100..))]
+    pub sample_rate_ms: u16,
+
+    /// Listen address for the HTTP server.
+    #[arg(short = 'a', long = "listen-address", default_value = "127.0.0.1:9810")]
+    pub listen_address: String,
+
+    /// Override embedded web templates with files from this directory.
+    #[arg(long)]
+    pub web_dir: Option<String>,
 }
 
 /// Hold color configuration.

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,4 +59,8 @@ pub enum Error {
     /// Error powermetrics exited with non-zero status.
     #[error("powermetrics ({0}), error: `{1}`")]
     PowermetricsNonZeroExit(process::ExitStatus, String),
+
+    /// Web server error.
+    #[error("web server error: `{0}`")]
+    WebServerError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,7 @@ mod modules;
 pub mod monitor;
 mod signal;
 mod ui;
+mod web;
 mod units;
 
 /// Result type for this crate.

--- a/src/modules/soc.rs
+++ b/src/modules/soc.rs
@@ -5,7 +5,7 @@ use std::process;
 use crate::{Result, error::Error};
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct SocInfo {
     /// Brand name of the CPU, e.g. "Apple M1".
     pub(crate) cpu_brand_name: String,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -19,10 +19,12 @@ use termion::{
     screen::IntoAlternateScreen,
 };
 
+use std::sync::{Arc, RwLock};
+
 use crate::{
     Result,
     app::App,
-    config::RunConfig,
+    config::{RunConfig, WebConfig},
     error::Error as CrateError,
     metrics,
     modules::{powermetrics, soc::SocInfo, sysinfo},
@@ -283,63 +285,107 @@ fn stream_metrics(tick_rate: Duration, tx: mpsc::Sender<Event>) -> Result<()> {
     Ok(())
 }
 
-// pub fn exec_stream<P: AsRef<Path>>(binary: P, args: Vec<&'static str>) {
-//     let mut cmd = process::Command::new(binary.as_ref())
-//         .args(&args)
-//         .stdout(process::Stdio::piped())
-//         .spawn()
-//         .unwrap();
-//
-//     {
-//         let stdout = cmd.stdout.as_mut().unwrap();
-//         let stdout_reader = BufReader::new(stdout);
-//         let stdout_lines = stdout_reader.lines();
-//
-//         let mut buffer: Vec<String> = vec![];
-//         for line in stdout_lines.flatten() {
-//             if line != "</plist>" {
-//                 // Process all lines but the last.
-//                 if line.starts_with(char::from(0)) {
-//                     // Trim the leading null character if present (happens only on the 1st line).
-//                     let line = line.trim_start_matches(char::from(0)).to_string();
-//                     buffer.push(line);
-//                 } else {
-//                     buffer.push(line);
-//                 }
-//             } else {
-//                 // Process the last line.
-//                 buffer.push(line);
-//
-//                 // Fix a powermetrics bug by removing the last `idle_ratio` line (n-5)th line.
-//                 let pos = buffer
-//                     .iter()
-//                     .rev()
-//                     .take(10)
-//                     .position(|line| line.starts_with("<key>idle_ratio</key>"));
-//                 if let Some(pos) = pos {
-//                     buffer.remove(buffer.len() - pos - 1);
-//                 }
-//
-//                 let text = buffer.join("\n");
-//                 buffer.clear();
-//                 if false {
-//                     println!("{}", text);
-//                     println!("--");
-//                 } else {
-//                     let powermetrics = match Metrics::from_bytes(text.as_bytes()) {
-//                         Ok(metrics) => metrics,
-//                         Err(err) => {
-//                             eprintln!("{err}");
-//                             eprintln!("{:?}", text.as_bytes());
-//                             cmd.kill().unwrap();
-//                             break;
-//                         }
-//                     };
-//                     println!("{}", powermetrics.cpu_mw);
-//                 }
-//             }
-//         }
-//     }
-//
-//     cmd.wait().unwrap();
-// }
+/// Run the web dashboard server.
+pub fn run_web(args: WebConfig) -> Result<()> {
+    let soc_info = SocInfo::new()?;
+    let tick_rate = Duration::from_millis(args.sample_rate_ms as u64);
+
+    let state = Arc::new(crate::web::SharedMetricsState {
+        metrics: RwLock::new(None),
+        soc_info,
+        web_dir: args.web_dir.map(std::path::PathBuf::from),
+    });
+
+    // Spawn metrics collection in a std thread (powermetrics requires sync I/O).
+    let st = state.clone();
+    thread::spawn(move || {
+        if let Err(err) = stream_powermetrics_to_state(tick_rate, &st) {
+            eprintln!("metrics collection error: {err}");
+        }
+    });
+
+    // Start axum server on tokio runtime.
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(crate::web::serve(state, args.listen_address))
+        .map_err(|e| CrateError::WebServerError(e.to_string()))?;
+    Ok(())
+}
+
+/// Stream powermetrics output and write to shared state (for the web dashboard).
+fn stream_powermetrics_to_state(
+    tick_rate: Duration,
+    state: &Arc<crate::web::SharedMetricsState>,
+) -> Result<()> {
+    let sample_rate_ms = format!("{}", tick_rate.as_millis());
+
+    let binary = "/usr/bin/powermetrics";
+    let args = [
+        "--sample-rate",
+        sample_rate_ms.as_str(),
+        "--samplers",
+        "cpu_power,gpu_power,thermal",
+        "-f",
+        "plist",
+    ];
+
+    let mut cmd = process::Command::new(binary)
+        .args(&args)
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()
+        .map_err(CrateError::PowermetricsSpawn)?;
+
+    let stdout = cmd.stdout.as_mut().ok_or(CrateError::PowermetricsStdout)?;
+    let stdout_reader = BufReader::new(stdout);
+    let stdout_lines = stdout_reader.lines();
+
+    let mut buffer = powermetrics::Buffer::new();
+    let mut system_state = sysinfo::SystemState::new();
+
+    for line in stdout_lines.map_while(std::result::Result::<String, io::Error>::ok) {
+        if line != "</plist>" {
+            buffer.append_line(line);
+        } else {
+            buffer.append_last_line(line);
+            let text = buffer.finalize();
+
+            let power_metrics = match metrics::Metrics::from_bytes(text.as_bytes()) {
+                Ok(metrics) => metrics,
+                Err(err) => {
+                    eprintln!("{err}");
+                    cmd.kill().map_err(CrateError::PowermetricsKill)?;
+                    break;
+                }
+            };
+
+            let sysinfo_metrics = system_state.latest_metrics();
+
+            let metrics = match power_metrics.merge_sysinfo_metrics(sysinfo_metrics) {
+                Ok(metrics) => metrics,
+                Err(err) => {
+                    eprintln!("{err}");
+                    cmd.kill().map_err(CrateError::PowermetricsKill)?;
+                    break;
+                }
+            };
+
+            // Write to shared state.
+            *state.metrics.write().unwrap() = Some(metrics);
+        }
+    }
+
+    let status = cmd.wait()?;
+    if !status.success() && status.code().is_some() {
+        let mut err_msg = String::new();
+        if let Some(mut stderr) = cmd.stderr.take() {
+            use std::io::Read;
+            stderr.read_to_string(&mut err_msg).ok();
+        }
+        return Err(CrateError::PowermetricsNonZeroExit(
+            status,
+            err_msg.trim().to_string(),
+        ));
+    }
+
+    Ok(())
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,0 +1,138 @@
+//! Web dashboard server using axum + ECharts.
+
+use std::{path::PathBuf, sync::Arc};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Response, StatusCode},
+    routing::get,
+    Router,
+};
+use rust_embed::RustEmbed;
+use serde_json::json;
+
+use crate::{metrics, modules::soc::SocInfo};
+
+/// Embedded web assets (compiled into the binary).
+#[derive(RustEmbed)]
+#[folder = "web/"]
+struct Assets;
+
+/// Shared state between metrics collection and HTTP handlers.
+pub(crate) struct SharedMetricsState {
+    pub(crate) metrics: std::sync::RwLock<Option<metrics::Metrics>>,
+    pub(crate) soc_info: SocInfo,
+    pub(crate) web_dir: Option<PathBuf>,
+}
+
+/// Run the axum HTTP server until shutdown.
+pub(crate) async fn serve(
+    state: Arc<SharedMetricsState>,
+    listen_addr: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let app = Router::new()
+        .route("/", get(index_handler))
+        .route("/api/metrics", get(metrics_handler))
+        .route("/api/config", get(config_handler))
+        .route("/assets/*path", get(assets_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
+    println!("Web dashboard listening on http://{listen_addr}");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Serve index.html.
+async fn index_handler(State(state): State<Arc<SharedMetricsState>>) -> Response<Body> {
+    serve_file("index.html", &state).await
+}
+
+/// Serve static assets (JS, CSS, etc.).
+async fn assets_handler(
+    State(state): State<Arc<SharedMetricsState>>,
+    axum::extract::Path(path): axum::extract::Path<String>,
+) -> Response<Body> {
+    serve_file(&path, &state).await
+}
+
+/// Try to read a file from web_dir first, then fall back to embedded assets.
+async fn serve_file(filename: &str, state: &SharedMetricsState) -> Response<Body> {
+    // Prefer web_dir override
+    if let Some(ref web_dir) = state.web_dir {
+        let file_path = web_dir.join(filename);
+        if let Ok(data) = tokio::fs::read(&file_path).await {
+            return ok_response(guess_mime(filename), data);
+        }
+    }
+
+    // Fall back to embedded assets
+    match Assets::get(filename) {
+        Some(content) => ok_response(guess_mime(filename), content.data.to_vec()),
+        None => not_found(),
+    }
+}
+
+fn ok_response(mime: &str, data: Vec<u8>) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", mime)
+        .body(Body::from(data))
+        .unwrap()
+}
+
+fn not_found() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("not found"))
+        .unwrap()
+}
+
+fn json_response(body: String) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+/// Return the latest metrics as JSON (with soc info).
+async fn metrics_handler(
+    State(state): State<Arc<SharedMetricsState>>,
+) -> Response<Body> {
+    let metrics_guard = state.metrics.read().unwrap();
+    let body = json!({
+        "soc": &state.soc_info,
+        "metrics": &*metrics_guard,
+    });
+    json_response(serde_json::to_string(&body).unwrap())
+}
+
+/// Return soc info and dashboard config.
+async fn config_handler(
+    State(state): State<Arc<SharedMetricsState>>,
+) -> Response<Body> {
+    let body = json!({
+        "soc": &state.soc_info,
+    });
+    json_response(serde_json::to_string(&body).unwrap())
+}
+
+fn guess_mime(path: &str) -> &'static str {
+    if path.ends_with(".html") {
+        "text/html"
+    } else if path.ends_with(".css") {
+        "text/css"
+    } else if path.ends_with(".js") {
+        "application/javascript"
+    } else if path.ends_with(".json") {
+        "application/json"
+    } else if path.ends_with(".svg") {
+        "image/svg+xml"
+    } else if path.ends_with(".png") {
+        "image/png"
+    } else {
+        "application/octet-stream"
+    }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,373 @@
+// Pumas Dashboard Application
+
+const MAX_HISTORY = 60;  // Keep 60 samples (~2 min at 2s interval)
+
+// History buffers keyed by series identifier
+const history = {};
+
+function initHistory(id) {
+    if (!history[id]) history[id] = { time: [], values: [] };
+    return history[id];
+}
+
+function pushHistory(id, time, value) {
+    const h = initHistory(id);
+    h.time.push(time);
+    h.values.push(value);
+    if (h.time.length > MAX_HISTORY) {
+        h.time.shift();
+        h.values.shift();
+    }
+}
+
+// ── Theme ──────────────────────────────────────────────────────────────
+
+function getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolveTheme(pref) {
+    if (pref === 'auto') return getSystemTheme();
+    return pref;
+}
+
+let currentTheme = resolveTheme(DASHBOARD_CONFIG.defaultTheme);
+
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.getElementById('themeBtn').textContent = theme === 'dark' ? '☀️' : '🌙';
+    localStorage.setItem('pumas-theme', theme);
+    currentTheme = theme;
+}
+
+function toggleTheme() {
+    const next = currentTheme === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+}
+
+// Listen for system theme changes when in auto mode
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (DASHBOARD_CONFIG.defaultTheme === 'auto') {
+        applyTheme(getSystemTheme());
+    }
+});
+
+// ── Adaptive frequency formatter ───────────────────────────────────────
+
+function formatFreq(v) {
+    return v >= 1000 ? (v / 1000).toFixed(2) + ' GHz' : v.toFixed(0) + ' MHz';
+}
+
+// ── ECharts helpers ────────────────────────────────────────────────────
+
+const charts = {};
+
+function createChart(id, height) {
+    const dom = document.getElementById(id);
+    if (!dom) return null;
+    dom.style.height = height + 'px';
+    const chart = echarts.init(dom, currentTheme === 'dark' ? 'dark' : null);
+    charts[id] = chart;
+    return chart;
+}
+
+function resizeAll() {
+    Object.values(charts).forEach(c => c && c.resize());
+}
+
+// ── Render functions ───────────────────────────────────────────────────
+
+function renderCpuUtil(metrics) {
+    const chart = charts['chart-cpuUtil'];
+    if (!chart) return;
+
+    const clusters = [
+        ...metrics.e_clusters.map(c => ({ ...c, kind: 'E' })),
+        ...metrics.p_clusters.map(c => ({ ...c, kind: 'P' })),
+        ...metrics.s_clusters.map(c => ({ ...c, kind: 'S' })),
+    ];
+
+    const now = Date.now();
+    const series = [];
+
+    for (const cluster of clusters) {
+        const id = cluster.name;
+        const avg = cluster.cpus.reduce((s, c) => s + c.active_ratio, 0) / cluster.cpus.length;
+        const pct = Math.max(0.1, avg * 100).toFixed(1);
+        pushHistory('util-' + id, now, pct);
+
+        const h = history['util-' + id];
+        series.push({
+            name: cluster.name,
+            type: 'line',
+            smooth: true,
+            data: h.values.map((v, i) => [h.time[i], v]),
+            symbol: 'none',
+            lineStyle: { width: 2 },
+        });
+    }
+
+    chart.setOption({
+        tooltip: { trigger: 'axis', valueFormatter: v => v + '%' },
+        legend: { data: clusters.map(c => c.name), bottom: 0 },
+        grid: { left: 45, right: 10, top: 30, bottom: 40 },
+        xAxis: { type: 'time', show: false },
+        yAxis: { type: 'log', min: 0.1, axisLabel: { formatter: '{value}%' } },
+        series,
+    }, true);
+}
+
+function renderCpuFreq(metrics) {
+    const chart = charts['chart-cpuFreq'];
+    if (!chart) return;
+
+    const clusters = [
+        ...metrics.e_clusters.map(c => ({ ...c, kind: 'E' })),
+        ...metrics.p_clusters.map(c => ({ ...c, kind: 'P' })),
+        ...metrics.s_clusters.map(c => ({ ...c, kind: 'S' })),
+    ];
+
+    const now = Date.now();
+    const series = [];
+
+    for (const cluster of clusters) {
+        const id = cluster.name;
+        pushHistory('freq-' + id, now, cluster.freq_mhz.toFixed(0));
+
+        const h = history['freq-' + id];
+        series.push({
+            name: cluster.name,
+            type: 'line',
+            smooth: true,
+            data: h.values.map((v, i) => [h.time[i], v]),
+            symbol: 'none',
+            lineStyle: { width: 2 },
+        });
+    }
+
+    chart.setOption({
+        tooltip: { trigger: 'axis', valueFormatter: v => formatFreq(v) },
+        legend: { data: clusters.map(c => c.name), bottom: 0 },
+        grid: { left: 60, right: 10, top: 30, bottom: 40 },
+        xAxis: { type: 'time', show: false },
+        yAxis: { type: 'value', axisLabel: { formatter: v => formatFreq(v) } },
+        series,
+    }, true);
+}
+
+function renderGpu(metrics) {
+    const chart = charts['chart-gpu'];
+    if (!chart) return;
+
+    const gpu = metrics.gpu;
+    const now = Date.now();
+
+    pushHistory('gpu-util', now, Math.max(0.1, gpu.active_ratio * 100).toFixed(1));
+    pushHistory('gpu-freq', now, gpu.freq_mhz.toFixed(0));
+
+    const utilH = history['gpu-util'];
+    const freqH = history['gpu-freq'];
+
+    chart.setOption({
+        tooltip: { trigger: 'axis' },
+        legend: { data: ['Utilization', 'Frequency'], bottom: 0 },
+        grid: { left: 45, right: 55, top: 30, bottom: 40 },
+        xAxis: { type: 'time', show: false },
+        yAxis: [
+            { type: 'log', min: 0.1, axisLabel: { formatter: '{value}%' } },
+            { type: 'value', axisLabel: { formatter: v => formatFreq(v) }, splitLine: { show: false } },
+        ],
+        series: [
+            {
+                name: 'Utilization',
+                type: 'line',
+                smooth: true,
+                data: utilH.values.map((v, i) => [utilH.time[i], v]),
+                symbol: 'none',
+                lineStyle: { width: 2, color: '#42a5f5' },
+                itemStyle: { color: '#42a5f5' },
+            },
+            {
+                name: 'Frequency',
+                type: 'line',
+                smooth: true,
+                yAxisIndex: 1,
+                data: freqH.values.map((v, i) => [freqH.time[i], v]),
+                symbol: 'none',
+                lineStyle: { width: 2, color: '#ff7043' },
+                itemStyle: { color: '#ff7043' },
+            },
+        ],
+    }, true);
+}
+
+function renderPower(metrics) {
+    const chart = charts['chart-power'];
+    if (!chart) return;
+
+    const { cpu_w, gpu_w, ane_w, package_w } = metrics.consumption;
+    const now = Date.now();
+
+    pushHistory('power-cpu', now, cpu_w);
+    pushHistory('power-gpu', now, gpu_w);
+    pushHistory('power-ane', now, ane_w);
+    pushHistory('power-pkg', now, package_w);
+
+    const series = ['cpu', 'gpu', 'ane'].map(k => {
+        const h = history['power-' + k];
+        return {
+            name: k.toUpperCase(),
+            type: 'line',
+            stack: 'total',
+            areaStyle: {},
+            smooth: true,
+            symbol: 'none',
+            data: h.values.map((v, i) => [h.time[i], v]),
+            lineStyle: { width: 1 },
+        };
+    });
+
+    const pkgH = history['power-pkg'];
+    series.push({
+        name: 'Package',
+        type: 'line',
+        smooth: true,
+        symbol: 'none',
+        lineStyle: { width: 2, type: 'dashed' },
+        data: pkgH.values.map((v, i) => [pkgH.time[i], v]),
+    });
+
+    chart.setOption({
+        tooltip: { trigger: 'axis', valueFormatter: v => v + ' W' },
+        legend: { data: ['CPU', 'GPU', 'ANE', 'Package'], bottom: 0 },
+        grid: { left: 40, right: 10, top: 30, bottom: 40 },
+        xAxis: { type: 'time', show: false },
+        yAxis: { type: 'value', axisLabel: { formatter: '{value} W' } },
+        series,
+    }, true);
+}
+
+function renderMemory(metrics) {
+    const mem = metrics.memory;
+    const ramPct = mem.ram_total > 0 ? ((mem.ram_used / mem.ram_total) * 100).toFixed(1) : 0;
+    const swapPct = mem.swap_total > 0 ? ((mem.swap_used / mem.swap_total) * 100).toFixed(1) : 0;
+
+    const fmt = v => {
+        if (v >= 1e12) return (v / 1e12).toFixed(1) + ' TB';
+        if (v >= 1e9) return (v / 1e9).toFixed(1) + ' GB';
+        if (v >= 1e6) return (v / 1e6).toFixed(1) + ' MB';
+        return v + ' B';
+    };
+
+    document.getElementById('mem-ram-text').textContent =
+        `${fmt(mem.ram_used)} / ${fmt(mem.ram_total)} (${ramPct}%)`;
+    document.getElementById('mem-ram-fill').style.width = ramPct + '%';
+
+    document.getElementById('mem-swap-text').textContent =
+        `${fmt(mem.swap_used)} / ${fmt(mem.swap_total)} (${swapPct}%)`;
+    document.getElementById('mem-swap-fill').style.width = swapPct + '%';
+}
+
+function renderThermal(metrics) {
+    const level = metrics.thermal_pressure.toLowerCase();
+    const el = document.getElementById('thermal-label');
+    el.textContent = metrics.thermal_pressure;
+
+    // Remove all color classes
+    el.className = 'thermal-label ' + level;
+
+    // Map level to fill width
+    const levels = { nominal: 10, light: 30, moderate: 50, heavy: 75, critical: 100 };
+    const fill = document.getElementById('thermal-fill');
+    const colors = { nominal: '#4caf50', light: '#8bc34a', moderate: '#ffc107', heavy: '#ff9800', critical: '#f44336' };
+    fill.style.width = (levels[level] || 10) + '%';
+    fill.style.background = colors[level] || '#4caf50';
+}
+
+// ── Status indicator ───────────────────────────────────────────────────
+
+function updateStatus(connected) {
+    const dot = document.getElementById('statusDot');
+    const text = document.getElementById('statusText');
+    if (connected) {
+        dot.className = 'status-dot active';
+        text.textContent = 'active';
+    } else {
+        dot.className = 'status-dot starting';
+        text.textContent = 'connecting...';
+    }
+}
+
+// ── Main poll loop ─────────────────────────────────────────────────────
+
+async function pollMetrics() {
+    try {
+        const resp = await fetch('/api/metrics');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const data = await resp.json();
+        updateStatus(true);
+
+        // Update SoC info header on first load
+        const socInfo = document.getElementById('socInfo');
+        if (socInfo && data.soc) {
+            socInfo.textContent = `${data.soc.cpu_brand_name} · ${data.soc.num_cpu_cores}C${data.soc.num_gpu_cores}G`;
+        }
+
+        renderCpuUtil(data.metrics);
+        renderCpuFreq(data.metrics);
+        renderGpu(data.metrics);
+        renderPower(data.metrics);
+        renderMemory(data.metrics);
+        renderThermal(data.metrics);
+
+    } catch (err) {
+        updateStatus(false);
+        console.warn('poll failed:', err);
+    }
+}
+
+// ── Init ───────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Restore saved theme or use default
+    const saved = localStorage.getItem('pumas-theme');
+    if (saved) {
+        applyTheme(saved);
+    } else {
+        applyTheme(resolveTheme(DASHBOARD_CONFIG.defaultTheme));
+    }
+
+    // Apply config-driven layout to cards
+    const cfg = DASHBOARD_CONFIG.charts;
+    for (const [key, chart] of Object.entries(cfg)) {
+        const card = document.getElementById('card-' + key);
+        if (!card) continue;
+        if (!chart.show) {
+            card.style.display = 'none';
+            continue;
+        }
+        card.style.gridRow = (chart.row + 1).toString();
+        card.style.gridColumn = `${chart.col + 1} / span ${chart.width}`;
+        // Set title from config
+        const titleEl = document.getElementById('title-' + key);
+        if (titleEl) titleEl.textContent = chart.title;
+
+        // Create chart or set height for non-chart cards
+        // Non-chart cards: thermal gets fixed height, memory auto-sizes to content
+        if (key === 'thermal') {
+            const el = document.getElementById('chart-' + key);
+            if (el) el.style.height = chart.height + 'px';
+        } else if (key === 'memory') {
+            // auto-height — no explicit size needed
+        } else {
+            createChart('chart-' + key, chart.height);
+        }
+    }
+
+    // Resize charts on window resize
+    window.addEventListener('resize', resizeAll);
+
+    // Start polling
+    pollMetrics();
+    setInterval(pollMetrics, DASHBOARD_CONFIG.refreshInterval);
+});

--- a/web/config.js
+++ b/web/config.js
@@ -1,0 +1,46 @@
+// Pumas Dashboard Configuration
+// Edit this file to customize the dashboard layout and behavior.
+const DASHBOARD_CONFIG = {
+    // How often to poll for new metrics (milliseconds)
+    refreshInterval: 2000,
+
+    // Default theme: 'light' | 'dark' | 'auto' (follows system preference)
+    defaultTheme: 'auto',
+
+    // Chart definitions.
+    // row/col: position in a 12-column CSS grid.
+    // width:  columns to span (1-12).
+    // height: chart container height in pixels.
+    charts: {
+        cpuUtil: {
+            show: true,
+            row: 0, col: 0, width: 6, height: 280,
+            title: 'CPU Utilization',
+        },
+        cpuFreq: {
+            show: true,
+            row: 0, col: 6, width: 6, height: 280,
+            title: 'CPU Frequency',
+        },
+        gpu: {
+            show: true,
+            row: 1, col: 0, width: 6, height: 280,
+            title: 'GPU',
+        },
+        power: {
+            show: true,
+            row: 1, col: 6, width: 6, height: 280,
+            title: 'Power Consumption',
+        },
+        memory: {
+            show: true,
+            row: 2, col: 0, width: 12, height: 220,
+            title: 'Memory',
+        },
+        thermal: {
+            show: true,
+            row: 3, col: 0, width: 12, height: 100,
+            title: 'Thermal Pressure',
+        },
+    },
+};

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pumas Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <div class="header">
+        <div>
+            <h1>Pumas <span class="subtitle" id="socInfo">Loading...</span></h1>
+        </div>
+        <div class="header-right">
+            <span class="status-indicator">
+                <span class="status-dot starting" id="statusDot"></span>
+                <span id="statusText">connecting...</span>
+            </span>
+            <button class="theme-btn" id="themeBtn" onclick="toggleTheme()">🌙</button>
+        </div>
+    </div>
+
+    <div class="dashboard-grid" id="dashboard">
+        <div class="chart-card" id="card-cpuUtil">
+            <h2 id="title-cpuUtil">CPU Utilization</h2>
+            <div class="chart-container" id="chart-cpuUtil"></div>
+        </div>
+        <div class="chart-card" id="card-cpuFreq">
+            <h2 id="title-cpuFreq">CPU Frequency</h2>
+            <div class="chart-container" id="chart-cpuFreq"></div>
+        </div>
+        <div class="chart-card" id="card-gpu">
+            <h2 id="title-gpu">GPU</h2>
+            <div class="chart-container" id="chart-gpu"></div>
+        </div>
+        <div class="chart-card" id="card-power">
+            <h2 id="title-power">Power Consumption</h2>
+            <div class="chart-container" id="chart-power"></div>
+        </div>
+        <div class="chart-card" id="card-memory">
+            <h2 id="title-memory">Memory</h2>
+            <div id="chart-memory">
+                <div class="memory-group">
+                    <div class="memory-item">
+                        <label>RAM</label>
+                        <div class="bar-track">
+                            <div class="bar-fill" id="mem-ram-fill" style="width: 0%"></div>
+                            <div class="bar-text" id="mem-ram-text">Loading...</div>
+                        </div>
+                    </div>
+                    <div class="memory-item">
+                        <label>Swap</label>
+                        <div class="bar-track">
+                            <div class="bar-fill" id="mem-swap-fill" style="width: 0%; background: linear-gradient(90deg, #ff7043, #e53935);"></div>
+                            <div class="bar-text" id="mem-swap-text">Loading...</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="chart-card" id="card-thermal">
+            <h2 id="title-thermal">Thermal Pressure</h2>
+            <div id="chart-thermal">
+                <div class="thermal-bar">
+                    <span class="thermal-label nominal" id="thermal-label">Nominal</span>
+                    <div class="thermal-track">
+                        <div class="thermal-fill" id="thermal-fill" style="width: 10%"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="assets/config.js"></script>
+    <script src="assets/app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,222 @@
+/* Pumas Dashboard Styles */
+:root {
+    --bg: #ffffff;
+    --bg-card: #f5f5f5;
+    --bg-card-hover: #ebebeb;
+    --text: #333333;
+    --text-secondary: #666666;
+    --border: #dddddd;
+    --accent: #4caf50;
+    --accent-hover: #388e3c;
+    --chart-grid: #e0e0e0;
+    --shadow: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] {
+    --bg: #1a1a2e;
+    --bg-card: #16213e;
+    --bg-card-hover: #1a1a3e;
+    --text: #e0e0e0;
+    --text-secondary: #999999;
+    --border: #2a2a4a;
+    --accent: #66bb6a;
+    --accent-hover: #81c784;
+    --chart-grid: #333355;
+    --shadow: rgba(0, 0, 0, 0.3);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    transition: background 0.3s, color 0.3s;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-card);
+}
+
+.header h1 {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.header .subtitle {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-left: 8px;
+}
+
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.status-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.status-dot.active {
+    background: #4caf50;
+    box-shadow: 0 0 6px #4caf50;
+}
+
+.status-dot.starting {
+    background: #ff9800;
+    animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+.theme-btn {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 16px;
+    color: var(--text);
+    transition: background 0.2s;
+}
+
+.theme-btn:hover {
+    background: var(--bg-card-hover);
+}
+
+/* Grid layout */
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 12px;
+    padding: 16px 24px;
+}
+
+.chart-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    transition: background 0.3s, border-color 0.3s;
+    box-shadow: 0 1px 3px var(--shadow);
+}
+
+.chart-card h2 {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+.chart-card .chart-container {
+    width: 100%;
+}
+
+/* Thermal indicator */
+.thermal-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 48px;
+}
+
+.thermal-label {
+    font-size: 24px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.thermal-label.nominal { color: #4caf50; }
+.thermal-label.light { color: #8bc34a; }
+.thermal-label.moderate { color: #ffc107; }
+.thermal-label.heavy { color: #ff9800; }
+.thermal-label.critical { color: #f44336; }
+
+.thermal-track {
+    flex: 1;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--border);
+    overflow: hidden;
+}
+
+.thermal-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.5s;
+}
+
+/* Memory bars */
+.memory-group {
+    display: flex;
+    gap: 24px;
+    padding: 4px 0;
+}
+
+.memory-item {
+    flex: 1;
+}
+
+.memory-item label {
+    font-size: 12px;
+    color: var(--text-secondary);
+    display: block;
+    margin-bottom: 4px;
+}
+
+.memory-item .bar-track {
+    height: 20px;
+    border-radius: 4px;
+    background: var(--border);
+    overflow: hidden;
+    position: relative;
+}
+
+.memory-item .bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.5s;
+    background: linear-gradient(90deg, #42a5f5, #1e88e5);
+}
+
+.memory-item .bar-text {
+    position: absolute;
+    top: 0;
+    left: 8px;
+    line-height: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+
+/* History charts */
+.history-container {
+    margin-top: 8px;
+}


### PR DESCRIPTION
## Summary

Introduce a new `pumas web` subcommand that starts an HTTP dashboard server accessible from a browser. Metrics collected by powermetrics are exposed via a REST API and rendered with ECharts for real-time data visualization.

Key changes:
- New `pumas web` subcommand with configurable listen address, sample rate, and web directory override
- axum HTTP server with REST API endpoints for metrics and configuration
- ECharts-based frontend dashboard with config-driven layout (12-column CSS grid)
- Real-time line charts for CPU utilization (log scale), CPU frequency, GPU (dual Y-axis), power consumption (stacked area), memory bars, and thermal indicator
- Light/dark theme with system preference detection and localStorage persistence
- Frontend assets embedded in the binary via rust-embed, no external files required at runtime

Usage:
sudo pumas web 
then browse http://localhost:9810
<img width="1488" height="1136" alt="截屏2026-04-27 14 02 03" src="https://github.com/user-attachments/assets/d2b5569b-0522-4233-b294-8e2a54b9a706" />

---


$(cat /Users/lf/vscode/pumas/docs/webdashboard.md)