### PR TITLE
ci(workflows): align job and step names to playbook

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
         with:
@@ -36,7 +36,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: cargo deny check
+      - name: Security – cargo deny
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -47,7 +47,7 @@ jobs:
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
 
-      - name: cargo pants
+      - name: Security – cargo pants
         run: |
           cargo install --locked cargo-pants || true
           cargo pants

--- a/.github/workflows/_ci-security.yml
+++ b/.github/workflows/_ci-security.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run zizmor
+      - name: Scan workflows (zizmor)
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
 
   poutine:
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run poutine
+      - name: Scan workflows (poutine)
         uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
 
       - name: Upload SARIF

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: Quality checks & tests
+    name: Build & test
     runs-on: macos-latest
     permissions:
       contents: read
@@ -23,7 +23,7 @@ jobs:
       matrix:
         rust: [stable]
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         if: github.event_name == 'pull_request'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
@@ -49,15 +49,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Quality - cargo fmt
+      - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: Quality - cargo clippy
+      - name: Quality – cargo clippy
         run: |
           cargo clippy --all-targets -- -D warnings
 
-      - name: Quality - convco check
+      - name: Quality – convco check
         run: |
           git show-ref
           echo Commit message: "$(git log -1 --pretty=%B)"
@@ -91,10 +91,12 @@ jobs:
       cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - id: filter
+      - name: Filter changed paths
+        id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: Prepare release artifacts
+    name: Build artifacts
     runs-on: macos-latest
     permissions:
       contents: read
@@ -25,7 +25,7 @@ jobs:
             suffix: ''
             archive_ext: zip
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Build Release
+      - name: Build (release)
         run: cargo build --release
 
       - name: Compress to zip
@@ -61,7 +61,7 @@ jobs:
           retention-days: 1
 
   release:
-    name: Create a GitHub Release
+    name: Publish release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -82,14 +82,14 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - name: Download convco
+      - name: Install convco
         run: |
           git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
 
-      - name: Use convco to create the changelog
+      - name: Generate changelog
         run: |
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
@@ -98,7 +98,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
 
-      - name: Create GitHub Release
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -108,7 +108,7 @@ jobs:
             --notes-file CHANGELOG.md \
             ./*.zip
 
-      - name: Attest build provenance
+      - name: Attest provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: '*.zip'

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   renovate:
-    name: Renovate
+    name: Run Renovate
     runs-on: ubuntu-latest
     environment: renovate
     permissions:


### PR DESCRIPTION
Cosmetic follow-up to #80, which renamed the workflow files and top-level
`name:` fields but left the per-job and per-step labels alone. Now the
GitHub Actions UI reads the same way across the playbook reference repos:
imperative job names (`Build & test`, `Run Renovate`, `Build artifacts`,
`Publish release`), step labels like `Install Rust` / `Cache crates` /
`Install convco` / `Generate changelog` / `Attest provenance`, and an
en-dash separator on the grouped `Quality – cargo …` and `Security –
cargo …` labels. The previously anonymous `Checkout` and
`dorny/paths-filter` steps in the `changes` job get explicit names too.

No behavior change.

After merge, the branch protection ruleset's required-checks list needs
another manual update in the GitHub UI: the entry pointing at
`CI: Essentials / Quality checks & tests` becomes `CI: Essentials / Build &
test`.