### PR TITLE
ci: third playbook pass — locked cargo, release layout, compat matrix

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -45,7 +45,7 @@ jobs:
             tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
-          cargo deny check
+          cargo deny --locked check
 
       - name: Security – cargo pants
         run: |

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,0 +1,69 @@
+# Compatibility testing: multi-version matrix on macOS.
+#
+# Pumas is Apple-Silicon-only (uses macOS `powermetrics`), so the standard
+# `test-all-platforms` job would collapse to a single row identical to
+# `ci-essentials.yml` and is omitted here. Only `test-all-versions` runs,
+# pinned to `macos-latest` because the crate does not compile on Linux.
+#
+# Local:
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+
+name: 'CI: Compatibility Matrix'
+
+on:
+  push:
+    branches:
+      - 'compat/*'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-all-versions:
+    name: macos-latest (${{ matrix.rust }})
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ['1.95.0', beta, nightly]
+    steps:
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Quality – cargo fmt
+        run: |
+          cargo fmt --all -- --check
+
+      - name: Quality – cargo clippy
+        run: |
+          cargo clippy --locked --all-targets -- -D warnings
+
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
+        with:
+          tool: cargo-nextest@0.9.133
+
+      - name: Test
+        run: ./ci/test_full.sh

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -69,10 +69,10 @@ jobs:
           rm convco
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build --locked --all-features
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --locked --all-features --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,15 @@
+# Tag-triggered release: build the Apple Silicon binary and publish.
+#
+# Local (requires act):
+#   act push -W .github/workflows/release.yml -j prepare-artifacts
+#   act push -W .github/workflows/release.yml -j release
+#   act push -W .github/workflows/release.yml -j homebrew
+#
+# pumas is Apple-Silicon-only (depends on macOS `powermetrics`, which
+# requires M-series silicon and root access). The release matrix is a
+# single row for `aarch64-apple-darwin`; do not add Linux, Windows, or
+# x86_64-apple-darwin entries.
+
 name: Release
 on:
   push:
@@ -7,84 +19,111 @@ on:
 permissions: {}
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   prepare-artifacts:
-    name: Build artifacts
-    runs-on: macos-latest
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write           # build provenance
+      attestations: write
+    defaults:
+      run:
+        shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            rust: stable
-            suffix: ''
-            archive_ext: zip
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.xz
     steps:
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
       - name: Build (release)
-        run: cargo build --release
-
-      - name: Compress to zip
         env:
-          REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "target/release/${REPO_NAME}"
+        run: cargo build --locked --release --target "${TARGET}"
 
-      - name: List files
+      - name: Stage binary and archive
+        env:
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_FORMAT: ${{ matrix.archive }}
+          TAG: ${{ github.ref_name }}
+          BIN: pumas
         run: |
-          ls -alF .
-          ls -alF target/release/
-        shell: bash
+          set -euo pipefail
+          SRC="target/${TARGET}/release/${BIN}"
 
-      - name: Upload artifacts
+          # Standalone binary: <bin>-<target>
+          STANDALONE="${BIN}-${TARGET}"
+          cp "${SRC}" "${STANDALONE}"
+
+          # Archive: <bin>-<tag>-<target>.tar.xz containing the binary,
+          # README, and LICENSE.
+          PKG_DIR="${BIN}-${TAG}-${TARGET}"
+          mkdir "${PKG_DIR}"
+          cp "${SRC}" "${PKG_DIR}/"
+          cp README.md LICENSE* "${PKG_DIR}/" 2>/dev/null || true
+
+          ARCHIVE_FILE="${PKG_DIR}.${ARCHIVE_FORMAT}"
+          tar -cJf "${ARCHIVE_FILE}" "${PKG_DIR}"
+
+          echo "STANDALONE=${STANDALONE}" >> "${GITHUB_ENV}"
+          echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> "${GITHUB_ENV}"
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ${{ env.STANDALONE }}
+            ${{ env.ARCHIVE_FILE }}
+
+      - name: Upload – standalone
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
-          path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          name: ${{ env.STANDALONE }}
+          path: ${{ env.STANDALONE }}
+          retention-days: 1
+
+      - name: Upload – archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.ARCHIVE_FILE }}
+          path: ${{ env.ARCHIVE_FILE }}
           retention-days: 1
 
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: write           # gh release create
     needs:
       - prepare-artifacts
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # convco needs all history to create the changelog
+          # convco needs full history for the changelog
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Extract version
-        id: extract-version
-        run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
-
       - name: Install convco
         run: |
-          git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
@@ -94,9 +133,11 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
+          path: artifacts
+          merge-multiple: true
 
       - name: Create GitHub release
         env:
@@ -106,12 +147,7 @@ jobs:
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.zip
-
-      - name: Attest provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: '*.zip'
+            ./artifacts/*
 
   homebrew:
     name: Bump Homebrew formula
@@ -136,7 +172,8 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: pumas

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,5 +5,6 @@ rules:
   superfluous-actions:
     ignore:
       - _cargo-audit.yml
+      - ci-compatibility-matrix.yml
       - ci-essentials.yml
       - release.yml

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -39,28 +39,28 @@ fi
 set -x
 
 # test the default
-cargo build
-cargo nextest run $NEXTEST_PROFILE
+cargo build --locked
+cargo nextest run --locked $NEXTEST_PROFILE
 
 # test `no_std`
-cargo build --no-default-features
-cargo nextest run $NEXTEST_PROFILE --no-default-features
+cargo build --locked --no-default-features
+cargo nextest run --locked $NEXTEST_PROFILE --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
-  # cargo build --no-default-features --features="std $feature"
-  # cargo nextest run $NEXTEST_PROFILE --no-default-features --features="std $feature"
+  # cargo build --locked --no-default-features --features="std $feature"
+  # cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="std $feature"
 
-  cargo build --no-default-features --features="$feature"
-  cargo nextest run $NEXTEST_PROFILE --no-default-features --features="$feature"
+  cargo build --locked --no-default-features --features="$feature"
+  cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
-# cargo build --features="std ${FEATURES[*]}"
-# cargo nextest run $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
+# cargo build --locked --features="std ${FEATURES[*]}"
+# cargo nextest run --locked $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
 
-cargo build --features="${FEATURES[*]}"
-cargo nextest run $NEXTEST_PROFILE --features="${FEATURES[*]}"
+cargo build --locked --features="${FEATURES[*]}"
+cargo nextest run --locked $NEXTEST_PROFILE --features="${FEATURES[*]}"
 
 # doc tests (not supported by nextest)
-cargo test --doc
+cargo test --locked --doc

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -27,8 +27,8 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
+# List crate-specific features here (none for pumas today).
 FEATURES=()
-# check_version 1.88 && FEATURES+=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 NEXTEST_PROFILE=""
@@ -42,25 +42,28 @@ set -x
 cargo build --locked
 cargo nextest run --locked $NEXTEST_PROFILE
 
-# test `no_std`
+# test --no-default-features
 cargo build --locked --no-default-features
 cargo nextest run --locked $NEXTEST_PROFILE --no-default-features
 
-# test each isolated feature, with and without std
+# test each feature in isolation
 for feature in "${FEATURES[@]}"; do
-  # cargo build --locked --no-default-features --features="std $feature"
-  # cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="std $feature"
-
   cargo build --locked --no-default-features --features="$feature"
   cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
-# test all supported features, with and without std
-# cargo build --locked --features="std ${FEATURES[*]}"
-# cargo nextest run --locked $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
-
+# test all features combined
 cargo build --locked --features="${FEATURES[*]}"
 cargo nextest run --locked $NEXTEST_PROFILE --features="${FEATURES[*]}"
+
+# CLI smoke test (release binary, target-aware path)
+cargo build --locked --release
+
+BIN="target/${CARGO_BUILD_TARGET:+${CARGO_BUILD_TARGET}/}release/pumas"
+case "${OSTYPE:-}" in
+  msys*|cygwin*) BIN="${BIN}.exe" ;;
+esac
+"${BIN}" --help
 
 # doc tests (not supported by nextest)
 cargo test --locked --doc

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
@@ -22,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },


### PR DESCRIPTION
Third pass through the github-actions-playbook, focusing on supply-chain
hardening and aligning the release workflow with the canonical layout.

Every `cargo` invocation across the workflows and `ci/test_full.sh` now
takes `--locked`, so a stale `Cargo.lock` fails CI loudly instead of
silently regenerating — closing the gap between what Renovate PRs were
tested with and what `release.yml` actually builds.

`release.yml` is restructured to match the playbook: matrix-driven job
display, per-target build provenance attestation, and a `Stage binary
and archive` step that emits both a standalone binary and a `tar.xz`
containing the binary + README + LICENSE. The matrix stays a single
row (`aarch64-apple-darwin`) — pumas depends on Apple-Silicon
`powermetrics`, so Linux/Windows/Intel are not viable targets.

A new `ci-compatibility-matrix.yml` runs MSRV/beta/nightly on
`compat/*` branches only. It is opt-in (no PR cost) but catches
upcoming-Rust breakage before a release tag. `test-all-platforms` is
intentionally absent for the same Apple-Silicon-only reason.

`renovate.json` pins `automergeStrategy: "merge-commit"` so it
agrees with the branch ruleset's allowed merge methods — otherwise the
GraphQL automerge call rejects silently and PRs sit unmerged with all
gates green.

`ci/test_full.sh` now folds a `--help` smoke test against the release
binary using a `CARGO_BUILD_TARGET`/`OSTYPE`-aware path, so every
compat-matrix row exercises the actual binary rather than just the
library. Commented-out `std`/`no_std` feature combinations were
dropped — pumas has no features and is not no_std.