### PR TITLE
ci(workflows): apply matrix-job naming conventions

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,12 +1,12 @@
 # Compatibility testing: multi-version matrix on macOS.
 #
 # Pumas is Apple-Silicon-only (uses macOS `powermetrics`), so the standard
-# `test-all-platforms` job would collapse to a single row identical to
-# `ci-essentials.yml` and is omitted here. Only `test-all-versions` runs,
+# `test-platforms` job would collapse to a single row identical to
+# `ci-essentials.yml` and is omitted here. Only `test-rust-versions` runs,
 # pinned to `macos-latest` because the crate does not compile on Linux.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
 
 name: 'CI: Compatibility Matrix'
 
@@ -22,8 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: macos-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: macos-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -19,14 +19,11 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -47,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality – cargo fmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Align the workflows with the playbook's matrix-job conventions so the
job key stays visible in check names and rendered run titles.

In ci-compatibility-matrix.yml the matrix job is renamed from the
generic test-all-versions to test-rust-versions (describes the
dimension it varies) and the redundant name: template is dropped so
GitHub auto-renders each variant as test-rust-versions (<rust>).

In ci-essentials.yml the single-value rust: [stable] matrix is gone;
stable is inlined into the toolchain and cache key. In release.yml
the name: ${{ matrix.target }} override is dropped from
prepare-artifacts for the same reason.

No CI logic changes — only field removals/renames per the playbook.