### PR TITLE
ci: sync six items from github-actions-playbook

### DIFF
--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -8,5 +8,4 @@ skip:
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
       - pkg:githubactions/renovatebot/github-action
-      - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/taiki-e/install-action

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -29,25 +29,21 @@ jobs:
         continue-on-error: false
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: cargo-deny@0.19.8
+
       - name: Security – cargo deny
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
-          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
-            tar zx --no-anchored cargo-deny --strip-components=1
-          chmod +x cargo-deny
-          mv cargo-deny ~/.cargo/bin/
-          cargo deny --locked check
+        run: cargo deny --locked check
 
       - name: Security – cargo pants
         run: |
-          cargo install --locked cargo-pants || true
+          cargo install --locked cargo-pants || command -v cargo-pants
           cargo pants

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -39,7 +39,6 @@ jobs:
         continue-on-error: false
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref, '-') }}
         run: |
           gh release create "${TAG_NAME}" \
+            --prerelease="${IS_PRERELEASE}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
             ./artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,13 @@ jobs:
       contents: read
     needs:
       - release
+    if: ${{ !contains(github.ref, '-') }} # skip prereleases (-rc, -alpha, -beta, ...)
+    env:
+      TAP_REPO: graelo/homebrew-tap
+      FORMULA_NAME: pumas
+      BOT_NAME: 'graelo-ci-bot[bot]'
+      BOT_USER_ID: '274240725'
+      REPO_URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -167,24 +174,37 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: graelo
           repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
 
-      - name: Extract version
-        id: extract-version
+      - name: Configure Homebrew, git, and gh for the bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+          # Linuxbrew is preinstalled on ubuntu-latest; put it on PATH for later steps.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"
+
+          # Tap the formula repo so `brew bump-formula-pr` can locate it by name.
+          brew tap "${TAP_REPO}"
+
+          # Configure git to push using the app token, and set the bot identity
+          # so the commit is attributed to ${BOT_NAME}.
+          gh auth setup-git
+          git config --global user.name  "${BOT_NAME}"
+          git config --global user.email "${BOT_USER_ID}+${BOT_NAME}@users.noreply.github.com"
 
       - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        if: '!contains(github.ref, ''-'')' # skip prereleases
-        with:
-          formula-name: pumas
-          homebrew-tap: graelo/homebrew-tap
-          push-to: graelo/homebrew-tap
-          create-pullrequest: true
-          download-url: https://github.com/graelo/pumas/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+          HOMEBREW_NO_ANALYTICS: '1'
+          HOMEBREW_NO_ENV_HINTS: '1'
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          brew bump-formula-pr \
+            --no-browse \
+            --no-fork \
+            --url="${REPO_URL}/archive/refs/tags/${TAG_NAME}.tar.gz" \
+            "${TAP_REPO}/${FORMULA_NAME}"

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          permission-statuses: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Apply six recent updates from `../github-actions-playbook` to the workflows here.

- **`ci(cargo-audit)`** — install `cargo-deny` via `taiki-e/install-action` (prebuilt binary, version-pinned) instead of curl-tarring the release asset; guard the `cargo-pants` install with `|| command -v cargo-pants` so a real install failure no longer gets swallowed by `|| true`; drop `~/.cargo/bin/` from the cache path list (rustup proxies live there and round-tripping can leave stale binaries).
- **`ci(ci-essentials)`** — same `~/.cargo/bin/` cache trim.
- **`ci(schedule-renovate)`** — add explicit `permission-<name>:` inputs to `actions/create-github-app-token` so the minted token doesn't carry every app installation permission (zizmor `github-app` rule).
- **`ci(release)` — prerelease tags** — pass `--prerelease="${IS_PRERELEASE}"` (cobra/pflag bool) to `gh release create` so `vX.Y.Z-rc.N` tags become GitHub pre-releases instead of "latest".
- **`ci(release)` — homebrew bump** — replace `mislav/bump-homebrew-formula-action` (unmaintained, requires a `poutine.yml` suppression) with Homebrew's own `brew bump-formula-pr` CLI. Linuxbrew is preinstalled on `ubuntu-latest`. Adds bot identity (`graelo-ci-bot[bot]`) for the formula commit, hoists per-project values into a job-level `env:` block, and moves the prerelease skip from step-level to job-level. App token scoped to `contents + pull-requests` only.

## Test plan

- [ ] CI: Essentials passes on this branch
- [ ] cargo-audit reusable workflow runs cleanly (Cargo.lock change is detected by `paths-filter`)
- [ ] Next tagged release (`vX.Y.Z` or `vX.Y.Z-rc.N`): verify the GitHub release is created with the right `prerelease` flag and the Homebrew formula bump PR opens on `graelo/homebrew-tap` only for non-prerelease tags
- [ ] Poutine no longer flags `mislav/bump-homebrew-formula-action` (it's gone)