### PR TITLE
ci: change renovate automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Switch Renovate's automerge strategy from `merge-commit` to `squash` so dependency update PRs land as a single commit instead of preserving the merge commit.